### PR TITLE
PLAT-29861: webpack bundle analysis support

### DIFF
--- a/global-cli/pack.js
+++ b/global-cli/pack.js
@@ -24,6 +24,7 @@ var
 	EnactFrameworkPlugin = require('../config/EnactFrameworkPlugin'),
 	EnactFrameworkRefPlugin = require('../config/EnactFrameworkRefPlugin'),
 	PrerenderPlugin = require('../config/PrerenderPlugin'),
+	BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin,
 	checkRequiredFiles = require('react-dev-utils/checkRequiredFiles'),
 	recursive = require('recursive-readdir'),
 	stripAnsi = require('strip-ansi');
@@ -182,6 +183,14 @@ function setupIsomorphic(config) {
 	}
 }
 
+function statsAnalyzer(config) {
+	config.plugins.push(new BundleAnalyzerPlugin({
+		analyzerMode: 'static',
+		reportFilename: 'stats.html',
+		openAnalyzer: false
+	}));
+}
+
 // Create the build and optionally, print the deployment instructions.
 function build(config, previousSizeMap, guided) {
 	if(process.env.NODE_ENV === 'development') {
@@ -238,6 +247,7 @@ function displayHelp() {
 	console.log('    enact pack [options]');
 	console.log();
 	console.log('  Options');
+	console.log('    -s, --stats       Output bundle analysis file');
 	console.log('    -w, --watch       Rebuild on file changes');
 	console.log('    -p, --production  Build in production mode');
 	console.log('    -i, --isomorphic  Use isomorphic code layout');
@@ -257,10 +267,10 @@ function displayHelp() {
 
 module.exports = function(args) {
 	var opts = minimist(args, {
-		boolean: ['minify', 'framework', 'p', 'production', 'i', 'isomorphic', 'w', 'watch', 'h', 'help'],
+		boolean: ['minify', 'framework', 's', 'stats', 'p', 'production', 'i', 'isomorphic', 'w', 'watch', 'h', 'help'],
 		string: ['externals', 'externals-inject'],
 		default: {minify:true},
-		alias: {p:'production', i:'isomorphic', w:'watch', h:'help'}
+		alias: {s:'stats', p:'production', i:'isomorphic', w:'watch', h:'help'}
 	});
 	opts.help && displayHelp();
 
@@ -290,6 +300,10 @@ module.exports = function(args) {
 		if(opts.externals) {
 			externalFramework(config, opts.externals, opts['externals-inject']);
 		}
+	}
+
+	if(opts.stats) {
+		statsAnalyzer(config);
 	}
 
 	// Warn and crash if required files are missing

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "style-loader": "~0.13.1",
     "webos-meta-webpack-plugin": "github:enyojs/webos-meta-webpack-plugin",
     "webpack": "~1.13.2",
+    "webpack-bundle-analyzer": "~1.4.1",
     "webpack-dev-server": "~1.16.2",
     "whatwg-fetch": "~1.0.0"
   }


### PR DESCRIPTION
Adds support for `-s`/`--stats` flag to create a stats.html file using https://github.com/th0r/webpack-bundle-analyzer

Works with all build modes (development, production, isomorphic, etc.).

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>