### PR TITLE
PLAT-29862:  give external framework builds an API to load all entrypoints

### DIFF
--- a/config/EnactFrameworkPlugin.js
+++ b/config/EnactFrameworkPlugin.js
@@ -49,9 +49,10 @@ function normalizeModuleID(id) {
 DllModule.prototype.source = function() {
 	var header = '';
 	if(DllModule.entries[this.name]) {
-		header += '__webpack_require__.load = function() {\n';
+		header += '__webpack_require__.load = function(loader) {\n';
+		header += '\tloader = loader || __webpack_require__;'
 		for(var i=0; i<DllModule.entries[this.name].length; i++) {
-			header += '\t__webpack_require__(\'' + DllModule.entries[this.name][i] + '\');\n';
+			header += '\tloader(\'' + DllModule.entries[this.name][i] + '\');\n';
 		}
 		header += '};\n';
 	}


### PR DESCRIPTION
Provides a top-level `load()` function which will run the webpack `require` function on all the entrypoint modules.  Supports passing a custom loader function for potential future uses.

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>