### PR TITLE
Add the correct path of ReactPerf depending on react version, for framework builds.

### DIFF
--- a/global-cli/pack.js
+++ b/global-cli/pack.js
@@ -128,7 +128,6 @@ function setupFramework(config) {
 	} else {
 		entry.push('react-dom/lib/ReactPerf');
 	}
-	console.log(entry);
 	config.entry = {enact:entry};
 
 	// Use universal module definition to allow usage and name as 'enact_framework'


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>