### PR TITLE
Set failOnEmptyTestSuite to true

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -39,7 +39,7 @@ module.exports = function(karma) {
 			[require.resolve('./proptype-checker')]: ['webpack']
 		},
 
-		failOnEmptyTestSuite: false,
+		failOnEmptyTestSuite: true,
 
 		webpack: {
 			// Use essentially the same webpack config as from the development build setup.


### PR DESCRIPTION
Switching `failOnEmptyTestSuite` to true. This will cause an error when there's an unfound module.

This shows a passing travis(shouldn't happen) before the change and reproducing the error.
https://travis-ci.com/enyojs/enact/builds/37460002

This shows a failing travis(should happen) after the change and reproducing the error.
https://travis-ci.com/enyojs/enact/builds/37459974

We originally set 'failOnEmptyTestSuite' to false to not fail on packages with "empty" test suites. We do have packages with no tests, but we have taken out the enact testing command from their `package.json`. Those will not cause travis to fail.

This shows after the change, but we're not reproducing the error. So the packages with no test suites aren't effected. 
https://travis-ci.com/enyojs/enact/builds/37461554

This will cause any project made with `enact-dev` to fail when there are no tests written. We can update the `enact-dev` template to have one starter test. Or we can make the decision to purposely fail those projects, which would be a way of letting developers know they need to write tests.

Enact-DCO-1.1-Signed-off-by: Derek Tor derek.tor@lge.com