### PR TITLE
PLAT-36503: Use 0.2.1 of webos-meta-webpack-plugin to support usePrer…

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "string.prototype.repeat": "~0.2.0",
     "strip-ansi": "~3.0.1",
     "style-loader": "~0.13.1",
-    "webos-meta-webpack-plugin": "enyojs/webos-meta-webpack-plugin#0.2.0",
+    "webos-meta-webpack-plugin": "enyojs/webos-meta-webpack-plugin#0.2.1",
     "webpack": "~1.14.0",
     "webpack-bundle-analyzer": "~2.1.1",
     "webpack-dev-server": "~1.16.2",


### PR DESCRIPTION
…endering appinfo.json updating.

Will tag webos-meta-webpack-plugin `0.2.1` after https://github.com/enyojs/webos-meta-webpack-plugin/pull/2 is merged.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>