### PR TITLE
PLAT-39086: too much memory used when prerendering all TV locales

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "react-dev-utils": "~0.5.0",
     "react-dom": "~15.4.2",
     "recursive-readdir": "~2.1.1",
-    "require-from-string": "~1.2.1",
     "resolution-independence": "~0.0.3",
     "rimraf": "~2.5.4",
     "semver": "~5.3.0",


### PR DESCRIPTION
Reduces memory by using a single VM context which the app in each locale gets processed each time. Noticable improvement in heap memory used at build-time.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>