### PR TITLE
Implement reading of the screen types json file so RI can work as exp…

### DIFF
--- a/global-cli/modifiers/isomorphic.js
+++ b/global-cli/modifiers/isomorphic.js
@@ -69,7 +69,8 @@ module.exports = function(config, opts) {
 			externals: opts.externals,
 			screenTypes:
 					(Array.isArray(enact.screenTypes) && enact.screenTypes)
-					|| (enact.screenTypes && (readJSON(enact.screenTypes) || readJSON(path.join('node_modules', enact.screenTypes))))
+					|| (typeof enact.screenTypes === 'string'
+						&& (readJSON(enact.screenTypes) || readJSON(path.join('node_modules', enact.screenTypes))))
 					|| readJSON(screenTypes(enact.gui || enact.theme || 'moonstone'))
 		}
 		if(!opts.locales) {


### PR DESCRIPTION
…ected.

The `enact.screentypes` property in `package.json` will now support the following values:
* Object value for screentypes directly.
* `moonstone`, `zircon`, `@enact/moonstone`, and `@enact/zircon` aliases to internally resolved filepaths.
* Direct path to a json file or a path to a node_module package's json file.
* Undefined value results in `moonstone` as the fallback.
* Empty object value to use no screentype definitions.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>