### PR TITLE
ENYO-4669: During prerendering some enact-locale classes don't apply.

### DIFF
--- a/global-cli/modifiers/util/LocaleHtmlPlugin.js
+++ b/global-cli/modifiers/util/LocaleHtmlPlugin.js
@@ -125,7 +125,8 @@ function simplifyAliases(locales, status) {
 
 			status.details[i].rootClasses = status.details[i].rootClasses || '';
 			if(!sharedCSS[status.alias[i]]) {
-				sharedCSS[status.alias[i]] = status.details[i].rootClasses.split(/\s+/);
+				sharedCSS[status.alias[i]] = commonClasses(status.details[i].rootClasses.split(/\s+/),
+						status.details[locales.indexOf(status.alias[i])].rootClasses.split(/\s+/));
 			} else {
 				sharedCSS[status.alias[i]] = commonClasses(sharedCSS[status.alias[i]],
 						status.details[i].rootClasses.split(/\s+/));
@@ -220,8 +221,8 @@ function localizedHtml(i, locales, status, html, compilation, htmlPlugin, callba
 		if(linked.length===0) {
 			// Single locale, re-inject root classes and react checksum.
 			status.prerender[i] = status.prerender[i]
-					.replace(/^(<[^>]*class="[^"]*)"/i, '$1' + status.details[i].rootClasses + '"')
-					.replace(/^(<[^>]*data-react-checksum=")"/i, '$1' + status.details[i].checksum + '"');
+					.replace(/(<div[^>]*class="[^"]*)"/i, '$1' + status.details[i].rootClasses + '"')
+					.replace(/(<div[^>]*data-react-checksum=")"/i, '$1' + status.details[i].checksum + '"');
 			emitAsset(compilation, 'index.' + locStr + '.html', htmlBefore + rootOpen + status.prerender[i]
 					+ rootClose + html.after);
 			localizedHtml(i+1, locales, status, html, compilation, htmlPlugin, callback);


### PR DESCRIPTION
One RegExp wasn't updated when we updated the others as part of https://github.com/enyojs/enact-dev/pull/90
Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>