### PR TITLE
PLAT-45654: Add support for Electron build type

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The enact-dev tool will check the project's `package.json` looking for an option
 * `screenTypes` _[array|string]_ - Array of 1 or more screentype definitions to be used with prerender HTML initialization. Can alternatively reference a json filepath to read for screentype definitons. Defaults to moonstone definitions.
 * `deep` _[string|array]_ - 1 or more javascript conditions that, when met, indicate deeplinking and any prerender should be discarded.
 * `node` _[object]_ - Configuration settings for polyfilling NodeJS built-ins. See `node` [webpack option](https://webpack.js.org/configuration/node/).
+* `target` _[string]_ - Build type preset for webpack with a default of `'web'`. See `target` [webpack option](https://webpack.js.org/configuration/target/).
 * `proxy` _[string]_ - Proxy target during project `serve` to be used within the [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware).
 
 For example:

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -79,6 +79,7 @@ module.exports = function(karma) {
 				net: 'empty',
 				tls: 'empty'
 			}),
+			target: enact.target || 'web',
 			module: {
 				rules: [
 					{

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -214,6 +214,9 @@ module.exports = {
 	},
 	// Optional configuration for polyfilling NodeJS built-ins.
 	node: enact.node,
+	// Build for 'web' unless otherwise specified.
+	target: enact.target || 'web',
+	// Ignore noisy performance warnings.
 	performance: {
 		hints: false
 	},

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -186,6 +186,9 @@ module.exports = {
 	},
 	// Optional configuration for polyfilling NodeJS built-ins.
 	node: enact.node,
+	// Build for 'web' unless otherwise specified.
+	target: enact.target || 'web',
+	// Ignore noisy performance warnings.
 	performance: {
 		hints: false
 	},

--- a/docs/starting-a-new-app.md
+++ b/docs/starting-a-new-app.md
@@ -19,6 +19,7 @@ The enact-dev tool will check the project's **package.json** looking for an opti
 * `screenTypes` _[array|string]_ - Array of 1 or more screentype definitions to be used with prerender HTML initialization. Can alternatively reference a json filepath to read for screentype definitons. Defaults to moonstone definitions.
 * `deep` _[string|array]_ - 1 or more javascript conditions that, when met, indicate deeplinking and any prerender should be discarded.
 * `node` _[object]_ - Configuration settings for polyfilling NodeJS built-ins. See `node` [webpack option](https://webpack.js.org/configuration/node/).
+* `target` _[string]_ - Build type preset for webpack with a default of `'web'`. See `target` [webpack option](https://webpack.js.org/configuration/target/).
 * `proxy` _[string]_ - Proxy target during project `serve` to be used within the [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware).
 
 For example:

--- a/template/README.md
+++ b/template/README.md
@@ -77,6 +77,7 @@ The enact-dev tool will check the project's `package.json` looking for an option
 * `screenTypes` _[array|string]_ - Array of 1 or more screentype definitions to be used with prerender HTML initialization. Can alternatively reference a json filepath to read for screentype definitons. Defaults to moonstone definitions.
 * `deep` _[string|array]_ - 1 or more javascript conditions that, when met, indicate deeplinking and any prerender should be discarded.
 * `node` _[object]_ - Configuration settings for polyfilling NodeJS built-ins. See `node` [webpack option](https://webpack.js.org/configuration/node/).
+* `target` _[string]_ - Build type preset for webpack with a default of `'web'`. See `target` [webpack option](https://webpack.js.org/configuration/target/).
 * `proxy` _[string]_ - Proxy target during project `serve` to be used within the [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware).
 
 For example:


### PR DESCRIPTION
Optional `target`value can be used to specify a webpack build target https://webpack.js.org/configuration/target/
Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>