### PR TITLE
ENYO-5148: Add global flag to disable in-bundle babel-polyfill loadin…

### DIFF
--- a/config/polyfills.js
+++ b/config/polyfills.js
@@ -5,13 +5,15 @@
  *  A collections of polyfills required prior to loading the app.
  */
 
-// Temporarily remap [Array].toLocaleString to [Array].toString.
-// Fixes an issue with loading the polyfills within the v8 snapshot environment
-// where toLocaleString() within the TypedArray polyfills causes snapshot failure.
-var origToLocaleString = Array.prototype.toLocaleString;
-Array.prototype.toLocaleString = Array.prototype.toString;
+if (typeof global === 'undefined' || !global.skipPolyfills) {
+	// Temporarily remap [Array].toLocaleString to [Array].toString.
+	// Fixes an issue with loading the polyfills within the v8 snapshot environment
+	// where toLocaleString() within the TypedArray polyfills causes snapshot failure.
+	var origToLocaleString = Array.prototype.toLocaleString;
+	Array.prototype.toLocaleString = Array.prototype.toString;
 
-require('@babel/polyfill');
+	require('@babel/polyfill');
 
-// Restore real [Array].toLocaleString for runtime usage.
-Array.prototype.toLocaleString = origToLocaleString;
+	// Restore real [Array].toLocaleString for runtime usage.
+	Array.prototype.toLocaleString = origToLocaleString;
+}


### PR DESCRIPTION
…g. Used during prerendering to avoid memory leaks.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>