### PR TITLE
ENYO-5287: CLI not respecting global._babelPolyfill and not correctly…

### DIFF
--- a/config/babel-proxy.js
+++ b/config/babel-proxy.js
@@ -1,0 +1,16 @@
+/*
+ *  babel-proxy.js
+ *
+ *  For babel-preset-env with "useBuiltin":"entry", it requires that the
+ *  require('@babel/polfill') expression be at the module level for it to
+ *  be transpiled into the individual core-js polyfills. This proxy module
+ *  allows for dynamic babel-polyfill usage while still using the core-js
+ *  transforms.
+ */
+
+// Apply Babel polyfills
+require('@babel/polyfill');
+
+// Manually set global._babelPolyfill for situations where babel-preset-env
+// transpiles into individual core-js polyfills, to avoid repeated usage.
+global._babelPolyfill = true;

--- a/config/polyfills.js
+++ b/config/polyfills.js
@@ -2,17 +2,18 @@
 /*
  *  polyfills.js
  *
- *  A collections of polyfills required prior to loading the app.
+ *  Any polyfills or code required prior to loading the app.
  */
 
-if (typeof global === 'undefined' || !global.skipPolyfills) {
+if (!global.skipPolyfills && !global._babelPolyfill) {
 	// Temporarily remap [Array].toLocaleString to [Array].toString.
 	// Fixes an issue with loading the polyfills within the v8 snapshot environment
 	// where toLocaleString() within the TypedArray polyfills causes snapshot failure.
 	var origToLocaleString = Array.prototype.toLocaleString;
 	Array.prototype.toLocaleString = Array.prototype.toString;
 
-	require('@babel/polyfill');
+	// Apply Babel polyfills
+	require('./babel-proxy');
 
 	// Restore real [Array].toLocaleString for runtime usage.
 	Array.prototype.toLocaleString = origToLocaleString;


### PR DESCRIPTION
… transpiling babel-polyfill requests into targeted core-js polyfills.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>