### PR TITLE
ENYO-5311: Disable calc optimization support in css-loader due to a bug where it…

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -143,7 +143,12 @@ module.exports = {
 							options: {
 								importLoaders: 2,
 								modules: true,
-								minimize: true
+								minimize: {
+									// Disable postcss-calc support within the css minifier due to
+									// an open bug where "calc" in a css variable name can break.
+									// See https://github.com/postcss/postcss-calc/issues/50
+									calc: false
+								}
 							}
 						},
 						{


### PR DESCRIPTION
…'s destroying css variable that include the word fragment "calc". Eg. --tooltip-calculated-offset. See https://github.com/postcss/postcss-calc/issues/50

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>