### PR TITLE
ENYO-5632: Add core-js as a dev dependency for local installs

### DIFF
--- a/commands/create.js
+++ b/commands/create.js
@@ -259,7 +259,7 @@ function api(opts = {}) {
 			.then(() => {
 				if (opts.local) {
 					console.log('Installing @enact/cli locally. This might take a couple minutes.');
-					return npmInstall(opts.directory, opts.verbose, '--save-dev', CORE_JS_NPM).then(() =>
+					return npmInstall(opts.directory, opts.verbose, '--save', CORE_JS_NPM).then(() =>
 						npmInstall(opts.directory, opts.verbose, '--save-dev', ENACT_DEV_NPM)
 					);
 				}

--- a/commands/create.js
+++ b/commands/create.js
@@ -18,6 +18,7 @@ const minimist = require('minimist');
 const validatePackageName = require('validate-npm-package-name');
 
 const ENACT_DEV_NPM = '@enact/cli';
+const CORE_JS_NPM = 'core-js@2';
 const INCLUDED = path.dirname(require.resolve('@enact/template-moonstone'));
 const TEMPLATE_DIR = path.join(process.env.APPDATA || os.homedir(), '.enact');
 
@@ -258,7 +259,7 @@ function api(opts = {}) {
 			.then(() => {
 				if (opts.local) {
 					console.log('Installing @enact/cli locally. This might take a couple minutes.');
-					return npmInstall(opts.directory, opts.verbose, '--save-dev', 'core-js@2').then(() =>
+					return npmInstall(opts.directory, opts.verbose, '--save-dev', CORE_JS_NPM).then(() =>
 						npmInstall(opts.directory, opts.verbose, '--save-dev', ENACT_DEV_NPM)
 					);
 				}

--- a/commands/create.js
+++ b/commands/create.js
@@ -258,7 +258,9 @@ function api(opts = {}) {
 			.then(() => {
 				if (opts.local) {
 					console.log('Installing @enact/cli locally. This might take a couple minutes.');
-					return npmInstall(opts.directory, opts.verbose, '--save-dev', ENACT_DEV_NPM);
+					return npmInstall(opts.directory, opts.verbose, '--save-dev', 'core-js@2').then(() =>
+						npmInstall(opts.directory, opts.verbose, '--save-dev', ENACT_DEV_NPM)
+					);
 				}
 			})
 			.then(() => generator.complete && generator.complete(params));


### PR DESCRIPTION
## Issue
When installing cli locally (e.g. via `enact create --locale test`), the babel polyfills can fail to be found if another package (e.g. `react`) has a dependency on a lower version of `core-js`.

## Resolution
Explicitly add the `core-js@2` dependency when using the `--local` option to ensure we have a compatible set of polyfills.

See: https://babeljs.io/docs/en/next/babel-preset-env.html#usebuiltins