### PR TITLE
Use loose mode on Babel stage-0 plugins

### DIFF
--- a/config/.babelrc.js
+++ b/config/.babelrc.js
@@ -22,7 +22,7 @@ module.exports = {
 				modules: false
 			}
 		],
-		'@babel/preset-stage-0',
+		['@babel/preset-stage-0', {loose: true}],
 		'@babel/preset-react'
 	],
 	plugins: [


### PR DESCRIPTION
Specifically needed for the stage-3 plugin for class properties to fix support for mobx and potentially other 3rd party software. Fixes the issue observed at https://github.com/enactjs/agate-apps/issues/45#issuecomment-424162741

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>