### PR TITLE
PLAT-71620: Implement optional Typescript linting support

### DIFF
--- a/commands/lint.js
+++ b/commands/lint.js
@@ -77,12 +77,16 @@ function tslintBin(context) {
 }
 
 function shouldTSLint(context) {
-	if (fs.existsSync(path.join(context, 'tslint.json'))) {
-		if (glob.sync('**/*.+(ts|tsx)', globOpts).length > 0) {
-			try {
-				return !spawn.sync(tslintBin(context), ['-v'], {stdio: 'ignore'}).error;
-			} catch (e) {
-				// ignore
+	if (glob.sync('**/*.+(ts|tsx)', globOpts).length > 0) {
+		try {
+			return !spawn.sync(tslintBin(context), ['-v'], {stdio: 'ignore'}).error;
+		} catch (e) {
+			if (fs.existsSync(path.join(context, 'tslint.json'))) {
+				console.warn(
+					'TSLint config file found, however TSLint could not be resolved.\n' +
+						'Install TSLint globally or locally on this project to ' +
+						'enable TypeScript linting.'
+				);
 			}
 		}
 	}

--- a/commands/lint.js
+++ b/commands/lint.js
@@ -1,7 +1,17 @@
 /* eslint-env node, es6 */
 const cp = require('child_process');
+const fs = require('fs');
 const path = require('path');
+const spawn = require('cross-spawn');
+const glob = require('glob');
 const minimist = require('minimist');
+const resolver = require('resolve');
+const {packageRoot} = require('@enact/dev-utils');
+
+const globOpts = {
+	ignore: ['node_modules/**', 'build/**', 'dist/**'],
+	nodir: true
+};
 
 function displayHelp() {
 	let e = 'node ' + path.relative(process.cwd(), __filename);
@@ -24,7 +34,11 @@ function displayHelp() {
 	process.exit(0);
 }
 
-function api({strict = false, local = false, fix = false, eslintArgs = []} = {}) {
+function shouldESLint() {
+	return glob.sync('**/*.+(js|jsx)', globOpts).length > 0;
+}
+
+function eslint({strict = false, local = false, fix = false, eslintArgs = []} = {}) {
 	let args = [];
 	if (strict) {
 		args.push('--no-eslintrc', '--config', require.resolve('eslint-config-enact/strict'));
@@ -41,7 +55,8 @@ function api({strict = false, local = false, fix = false, eslintArgs = []} = {})
 		args.push('.');
 	}
 	return new Promise((resolve, reject) => {
-		const child = cp.fork(require.resolve('eslint/bin/eslint'), args, {env: process.env, cwd: process.cwd()});
+		const opts = {env: process.env, cwd: process.cwd()};
+		const child = cp.fork(require.resolve('eslint/bin/eslint'), args, opts);
 		child.on('close', code => {
 			if (code !== 0) {
 				reject();
@@ -50,6 +65,52 @@ function api({strict = false, local = false, fix = false, eslintArgs = []} = {})
 			}
 		});
 	});
+}
+
+function tslintBin(context) {
+	try {
+		resolver.sync('tslint', {basedir: context});
+		return path.join(context, 'node_modules', '.bin', 'tslint');
+	} catch (e) {
+		return 'tslint';
+	}
+}
+
+function shouldTSLint(context) {
+	if (fs.existsSync(path.join(context, 'tslint.json'))) {
+		if (glob.sync('**/*.+(ts|tsx)', globOpts).length > 0) {
+			try {
+				return !spawn.sync(tslintBin(context), ['-v'], {stdio: 'ignore'}).error;
+			} catch (e) {
+				// ignore
+			}
+		}
+	}
+	return false;
+}
+
+function tslint({fix = false} = {}, context) {
+	const args = ['-p', context];
+	if (fix) args.push('--fix');
+
+	return new Promise((resolve, reject) => {
+		const opts = {env: process.env, cwd: process.cwd(), stdio: 'inherit'};
+		const child = spawn(tslintBin(context), args, opts);
+		child.on('close', code => {
+			if (code !== 0) {
+				reject();
+			} else {
+				resolve();
+			}
+		});
+	});
+}
+
+function api(opts) {
+	const context = packageRoot().path;
+	return Promise.resolve()
+		.then(() => shouldESLint() && eslint(opts))
+		.then(() => shouldTSLint(context) && tslint(opts, context));
 }
 
 function cli(args) {

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -76,11 +76,15 @@ Note: Changing any environment variables will require you to restart the develop
 
 ## TypeScript Support
 
-[TypeScript](https://www.typescriptlang.org) syntax support is an optional feature.  All TypeScript-based code will be automatically transpiled like normal JavaScript and packaged by Enact CLI with no additional user setup needed. However, this does not inlude enforced type-checking, solely the syntax transpiling.  Type-checking will occur automatically at buildtime, however the `typescript` dependency must be on the project itself.  You'llalso want to install type definition packages for React, ReactDOM, and Jest.
+[TypeScript](https://www.typescriptlang.org) syntax support is an optional feature.  All TypeScript-based code will be automatically transpiled like normal JavaScript and packaged by Enact CLI with no additional user setup needed. However, this does not inlude enforced type-checking, solely the syntax transpiling.  Type-checking will occur automatically at buildtime, however the `typescript` dependency must be on the project itself.  You'll also want to install type definition packages for React, ReactDOM, and Jest.
+
+It's easiest to begin from the start with TypeScript by using the `typescript` template (`@enact/template-typescript` on NPM). To add TypeScript support to an existing project:
 
 ```
 npm install --save typescript @types/react @types/react-dom @types/jest
 ```
+
+Optionally, [TSLint](https://palantir.github.io/tslint/) can be installed globally or locally and configured within a project to enable linting support within the `enact lint` command.
 
 ## Isomorphic Support & Prerendering
 By using the isomorphic code layout option, your project bundle will be outputted in a versatile universal code format allowing potential usage outside the browser. The Enact CLI takes advantage of this mode by additionally generating an HTML output of your project and embedding it directly with the resulting **index.html**. By default, isomorphic mode will attempt to prerender only `en-US`, however with the `--locales` option, a wade variety of locales can be specified and prerendered. More details on isomorphic support and its limitations can be found [here](./isomorphic-support.md).

--- a/docs/loading-existing-app.md
+++ b/docs/loading-existing-app.md
@@ -26,6 +26,6 @@ npm tasks vary by package and are defined within a `scripts` object in the **pac
 * `npm run pack-p` - Packages the app into **./dist** in production mode (minified code, with development code dropped).
 * `npm run watch` - Packages in development mode and sets up a watcher that will rebuild the app whenever the source code changes.
 * `npm run test` - Builds and executes any test spec files within the project.
-* `npm run lint `- Lints the project's JavaScript files according to the Enact ESLint configuration settings.
+* `npm run lint `- Lints the project's JavaScript files according to the Enact ESLint configuration settings and optionally TSLint.
 * `npm run clean` - Deletes the **./dist** directory
 * `npm run license` - Outputs a list of licenses used by modules required by the project

--- a/docs/starting-a-new-app.md
+++ b/docs/starting-a-new-app.md
@@ -58,7 +58,7 @@ Included within the project template are a number of npm tasks available, with e
 * `npm run pack-p` - Packages the app into **./dist** in production mode (minified code, with development code dropped).
 * `npm run watch` - Packages in development mode and sets up a watcher that will rebuild the app whenever the source code changes.
 * `npm run test` - Builds and executes any test spec files within the project.
-* `npm run lint `- Lints the project's JavaScript files according to the Enact ESLint configuration settings.
+* `npm run lint `- Lints the project's JavaScript files according to the Enact ESLint configuration settings and optionally TSLint.
 * `npm run clean` - Deletes the **./dist** directory
 
 That's it! Now you have a fully functioning app environment.


### PR DESCRIPTION
Modifies `enact lint`. When js/jsx files exist, runs `eslint`. When ts/tsx files exist, and so does a `tslint.json`, and TSLint is installed locally or globally, run `tslint`.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>