### PR TITLE
PLAT-72577: CRA-style POC css ident generation.

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -18,6 +18,7 @@ const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin-alt');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent');
 const eslintFormatter = require('react-dev-utils/eslintFormatter');
 const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
@@ -156,7 +157,7 @@ module.exports = {
 							importLoaders: 2,
 							modules: true,
 							sourceMap: true,
-							localIdentName: '[name]__[local]___[hash:base64:5]'
+							getLocalIdent: getCSSModuleLocalIdent
 						}
 					},
 					{

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -19,6 +19,7 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin-alt')
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent');
 const eslintFormatter = require('react-dev-utils/eslintFormatter');
 const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
 const LessPluginRi = require('resolution-independence');
@@ -142,7 +143,8 @@ module.exports = {
 						loader: require.resolve('css-loader'),
 						options: {
 							importLoaders: 2,
-							modules: true
+							modules: true,
+							getLocalIdent: getCSSModuleLocalIdent
 						}
 					},
 					{


### PR DESCRIPTION
Uses the `create-react-app` style of CSSS output for modular unique identities (for both development and production modes):
* `[filename]_[localclass]__[hash:5]` where the hash is based off the resource filepath rather than the resource content.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>