### PR TITLE
PLAT-72577: PoC where CSS module local ident is a hash based off the …

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -18,14 +18,13 @@ const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin-alt');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent');
 const eslintFormatter = require('react-dev-utils/eslintFormatter');
 const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
 const LessPluginRi = require('resolution-independence');
 const resolve = require('resolve');
 const {DefinePlugin, EnvironmentPlugin} = require('webpack');
-const {optionParser: app, GracefulFsPlugin, ILibPlugin, WebOSMetaPlugin} = require('@enact/dev-utils');
+const {optionParser: app, cssModuleIdent, GracefulFsPlugin, ILibPlugin, WebOSMetaPlugin} = require('@enact/dev-utils');
 
 process.chdir(app.context);
 process.env.NODE_ENV = 'development';
@@ -157,7 +156,7 @@ module.exports = {
 							importLoaders: 2,
 							modules: true,
 							sourceMap: true,
-							getLocalIdent: getCSSModuleLocalIdent
+							getLocalIdent: cssModuleIdent
 						}
 					},
 					{

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -18,6 +18,7 @@ const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin-alt');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent');
 const eslintFormatter = require('react-dev-utils/eslintFormatter');
 const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
@@ -156,7 +157,7 @@ module.exports = {
 							importLoaders: 2,
 							modules: true,
 							sourceMap: true,
-							localIdentName: '[name]__[local]___[hash:base64:5]'
+							getLocalIdent: getCSSModuleLocalIdent
 						}
 					},
 					{

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -19,6 +19,7 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin-alt')
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent');
 const eslintFormatter = require('react-dev-utils/eslintFormatter');
 const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
 const LessPluginRi = require('resolution-independence');
@@ -142,7 +143,8 @@ module.exports = {
 						loader: require.resolve('css-loader'),
 						options: {
 							importLoaders: 2,
-							modules: true
+							modules: true,
+							getLocalIdent: getCSSModuleLocalIdent
 						}
 					},
 					{

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -19,14 +19,13 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin-alt')
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
-const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent');
 const eslintFormatter = require('react-dev-utils/eslintFormatter');
 const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
 const LessPluginRi = require('resolution-independence');
 const resolve = require('resolve');
 const TerserPlugin = require('terser-webpack-plugin');
 const {DefinePlugin, EnvironmentPlugin} = require('webpack');
-const {optionParser: app, GracefulFsPlugin, ILibPlugin, WebOSMetaPlugin} = require('@enact/dev-utils');
+const {optionParser: app, cssModuleIdent, GracefulFsPlugin, ILibPlugin, WebOSMetaPlugin} = require('@enact/dev-utils');
 
 process.chdir(app.context);
 process.env.NODE_ENV = 'production';
@@ -144,7 +143,7 @@ module.exports = {
 						options: {
 							importLoaders: 2,
 							modules: true,
-							getLocalIdent: getCSSModuleLocalIdent
+							getLocalIdent: cssModuleIdent
 						}
 					},
 					{


### PR DESCRIPTION
…content resource path and local classname (rather than resource content).

In-house alternative to https://github.com/enactjs/cli/pull/163
Requires https://github.com/enactjs/dev-utils/pull/34

Updates CSS modular local ident to:
* Development mode: `[filename]_[localclass]__[hash:5]` with hash is based off the resource filepath
* Production mode: `[hash:10]` based off resource path and local classname

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>