### PR TITLE
ENYO-5772: Can't import aliased ilib path while testing

### DIFF
--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -9,6 +9,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+const path = require('path');
 const {packageRoot} = require('@enact/dev-utils');
 
 // Do this as the first thing so that any code reading it knows the right env.
@@ -56,7 +57,9 @@ module.exports = {
 	],
 	moduleNameMapper: {
 		'^.+\\.module\\.(css|less)$': require.resolve('identity-obj-proxy'),
-		'^enzyme$': require.resolve('enzyme')
+		'^enzyme$': require.resolve('enzyme'),
+		'^ilib$': path.join(pkg.path, globals.ILIB_BASE_PATH, 'lib', 'ilib.js'),
+		'^ilib[/\\\\](.*)$': path.join(pkg.path, globals.ILIB_BASE_PATH, 'lib', '$1')
 	},
 	moduleFileExtensions: ['js', 'jsx', 'json', 'ts', 'tsx'],
 	globals


### PR DESCRIPTION
Adds `ilib` alias support for tests; both for standalone `ilib` and `ilib/...` paths.

Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>