### PR TITLE
PLAT-73957: Travis failures after CLI 2.0.0 release

### DIFF
--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -34,7 +34,7 @@ if (pkg.meta.name === '@enact/moonstone') {
 	globals.ILIB_BASE_PATH = 'ilib';
 }
 
-const ignore = [
+const ignorePatterns = [
 	// Common directories to ignore
 	'/node_modules/',
 	'<rootDir>/(.*/)*coverage/',
@@ -44,7 +44,7 @@ const ignore = [
 
 module.exports = {
 	collectCoverageFrom: ['**/*.{js,jsx,ts,tsx}', '!**/*.d.ts'],
-	coveragePathIgnorePatterns: ignore,
+	coveragePathIgnorePatterns: ignorePatterns,
 	setupFiles: [require.resolve('../polyfills')],
 	setupFilesAfterEnv: [require.resolve('./setupTests')],
 	testMatch: [
@@ -52,7 +52,7 @@ module.exports = {
 		'<rootDir>/**/?(*.)(spec|test).{js,jsx,ts,tsx}',
 		'<rootDir>/**/*-specs.{js,jsx,ts,tsx}'
 	],
-	testPathIgnorePatterns: ignore,
+	testPathIgnorePatterns: ignorePatterns,
 	testEnvironment: 'jsdom',
 	testEnvironmentOptions: {pretendToBeVisual: true},
 	testURL: 'http://localhost',

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -37,9 +37,9 @@ if (pkg.meta.name === '@enact/moonstone') {
 const ignore = [
 	// Common directories to ignore
 	'/node_modules/',
-	'<rootDir>/.*coverage/',
-	'<rootDir>/.*build/',
-	'<rootDir>/.*dist/'
+	'<rootDir>/(.*/)*coverage/',
+	'<rootDir>/(.*/)*build/',
+	'<rootDir>/(.*/)*dist/'
 ];
 
 module.exports = {

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -34,9 +34,17 @@ if (pkg.meta.name === '@enact/moonstone') {
 	globals.ILIB_BASE_PATH = 'ilib';
 }
 
+const ignore = [
+	// Common directories to ignore
+	'/node_modules/',
+	'<rootDir>/.*coverage/',
+	'<rootDir>/.*build/',
+	'<rootDir>/.*dist/'
+];
+
 module.exports = {
 	collectCoverageFrom: ['**/*.{js,jsx,ts,tsx}', '!**/*.d.ts'],
-	coveragePathIgnorePatterns: ['/node_modules/', '/build/', '/dist/', '/coverage/'],
+	coveragePathIgnorePatterns: ignore,
 	setupFiles: [require.resolve('../polyfills')],
 	setupFilesAfterEnv: [require.resolve('./setupTests')],
 	testMatch: [
@@ -44,7 +52,7 @@ module.exports = {
 		'<rootDir>/**/?(*.)(spec|test).{js,jsx,ts,tsx}',
 		'<rootDir>/**/*-specs.{js,jsx,ts,tsx}'
 	],
-	testPathIgnorePatterns: ['/node_modules/', '/build/', '/dist/', '/coverage/'],
+	testPathIgnorePatterns: ignore,
 	testEnvironment: 'jsdom',
 	testEnvironmentOptions: {pretendToBeVisual: true},
 	testURL: 'http://localhost',


### PR DESCRIPTION
Ensures out-out-project parent directories named 'coverage', 'build', and 'dist' don't accidentally cause all tests to be ignored.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>