### PR TITLE
PLAT-76550: Support custom NPM global prefix paths in CLI linking

### DIFF
--- a/commands/link.js
+++ b/commands/link.js
@@ -3,7 +3,6 @@ const path = require('path');
 const chalk = require('chalk');
 const spawn = require('cross-spawn');
 const fs = require('fs-extra');
-const globalDir = require('global-modules');
 const minimist = require('minimist');
 const packageRoot = require('@enact/dev-utils').packageRoot;
 
@@ -19,36 +18,61 @@ function displayHelp() {
 	process.exit(0);
 }
 
+function globalModules() {
+	return new Promise(resolve => {
+		let prefix = '';
+		const proc = spawn('npm', ['config', 'get', 'prefix', '-g'], {
+			stdio: 'pipe',
+			cwd: process.cwd(),
+			env: process.env
+		});
+		proc.stdout.on('data', data => {
+			prefix += data.toString().replace(/\n/g, '');
+		});
+		proc.on('close', code => {
+			if (code !== 0 || !prefix) {
+				resolve(require('global-modules'));
+			} else if (process.platform === 'win32' || ['msys', 'cygwin'].includes(process.env.OSTYPE)) {
+				resolve(path.resolve(prefix, 'node_modules'));
+			} else {
+				resolve(path.resolve(prefix, 'lib/node_modules'));
+			}
+		});
+	});
+}
+
 function api({verbose = false} = {}) {
 	const linkArgs = ['--loglevel', verbose ? 'verbose' : 'error', 'link'];
 	const pkg = packageRoot();
 	let enact = Object.keys(pkg.meta.dependencies || {}).concat(Object.keys(pkg.meta.devDependencies || {}));
 	enact = enact.filter(d => d.startsWith('@enact/')).map(d => d.replace('@enact/', ''));
 
-	return new Promise((resolve, reject) => {
-		const missing = [];
-		for (let i = 0; i < enact.length; i++) {
-			if (fs.existsSync(path.join(globalDir, '@enact', enact[i]))) {
-				linkArgs.push('@enact/' + enact[i]);
-			} else {
-				missing.push('@enact/' + enact[i]);
-			}
-		}
-
-		if (enact.length === 0) {
-			reject(new Error('No Enact dependencies found within the package. Nothing to link.'));
-		} else if (missing.length === enact.length) {
-			reject(new Error('Unable to detect any Enact global modules. Please ensure they are linked correctly.'));
-		} else {
-			const proc = spawn('npm', linkArgs, {stdio: 'inherit', cwd: process.cwd()});
-			proc.on('close', code => {
-				if (code !== 0) {
-					reject(new Error('"npm ' + linkArgs.join(' ') + '" failed'));
+	return globalModules().then(globalDir => {
+		return new Promise((resolve, reject) => {
+			const missing = [];
+			for (let i = 0; i < enact.length; i++) {
+				if (fs.existsSync(path.join(globalDir, '@enact', enact[i]))) {
+					linkArgs.push('@enact/' + enact[i]);
 				} else {
-					resolve();
+					missing.push('@enact/' + enact[i]);
 				}
-			});
-		}
+			}
+
+			if (enact.length === 0) {
+				reject(new Error('No Enact dependencies found within the package. Nothing to link.'));
+			} else if (missing.length === enact.length) {
+				reject(new Error('Enact global modules not found. Ensure they are linked correctly.'));
+			} else {
+				const proc = spawn('npm', linkArgs, {stdio: 'inherit', cwd: process.cwd()});
+				proc.on('close', code => {
+					if (code !== 0) {
+						reject(new Error('"npm ' + linkArgs.join(' ') + '" failed'));
+					} else {
+						resolve();
+					}
+				});
+			}
+		});
 	});
 }
 


### PR DESCRIPTION
Uses `npm config get prefix -g` to resolve global module path to allow for custom paths via npmrc configs.  Falls back to `global-modules` package.

Previously, the `enact link` process was relying on the `global-modules` library to determine where linked modules are globally installed (and then would link any available `@enact/*` ones that were also in the local `package.json`). However `global-modules` does not take into account when the global NPM prefix is set to something custom (can be done via multiple means). This update uses `npm config get prefix -g` to determine the final module path more thoroughly.

For example, on Jenkins we set `NPM_CONFIG_GLOBALCONFIG` env var to a local `/home/jenkins/workspace/job/.npmrc` value, which includes `PREFIX="/home/jenkins/workspace/job/npm"`. Under NPM, global modules would be installed/linked to 
`/home/jenkins/workspace/job/npm/lib/node_modules` then. However the `global-modules` package with its static approach simply returns the OS-default `/usr/local/lib/node_modules`. The NPM config command, `npm config get prefix -g`, on the other hand, returns the true resolved custom path set.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>