### PR TITLE
ENYO-5894: Change serve command to use inline CSS in style tags

### DIFF
--- a/commands/serve.js
+++ b/commands/serve.js
@@ -161,21 +161,6 @@ function serve(config, host, port, open) {
 			webpack
 		});
 
-		// Temporary workaround for react-dev-utils/WebpackDevServerUtils
-		// CRA uses a beforeCompile hook to signify the beginning of a compilation, however the
-		// hook is executed for mini-css-extract-plugin too, which results in the promise being
-		// overriden and the system hanging. This fix extracts their hook callback and manually
-		// invokes it on non-CSS compilation events.
-		const taps = compiler.hooks.beforeCompile.taps;
-		const craServeHook = taps[taps.length - 1];
-		const hookFn = craServeHook.fn;
-		craServeHook.fn = function() {};
-		compiler.hooks.compilation.tap('EnactCLI', ({name}) => {
-			if (name && !name.startsWith('mini-css-extract-plugin')) {
-				hookFn();
-			}
-		});
-
 		compiler.hooks.afterEmit.tapAsync('EnactCLI', (compilation, callback) => {
 			compilation.warnings.forEach(w => {
 				if (w.message) {

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -62,7 +62,7 @@ module.exports = function(env) {
 		// bundles will stilluse the "style" loader inside the async code so CSS
 		// from them won't be in the main CSS file.
 		const loaders = [
-			MiniCssExtractPlugin.loader,
+			isEnvProduction ? MiniCssExtractPlugin.loader : require.resolve('style-loader'),
 			{
 				loader: require.resolve('css-loader'),
 				options: Object.assign(
@@ -378,10 +378,11 @@ module.exports = function(env) {
 			// Inject prefixed environment variables within code, when used
 			new EnvironmentPlugin(Object.keys(process.env).filter(key => /^REACT_APP_/.test(key))),
 			// Note: this won't work without MiniCssExtractPlugin.loader in `loaders`.
-			new MiniCssExtractPlugin({
-				filename: '[name].css',
-				chunkFilename: 'chunk.[name].css'
-			}),
+			isEnvProduction &&
+				new MiniCssExtractPlugin({
+					filename: '[name].css',
+					chunkFilename: 'chunk.[name].css'
+				}),
 			// Ensure correct casing in module filepathes
 			new CaseSensitivePathsPlugin(),
 			// If you require a missing module and then `npm install` it, you still have


### PR DESCRIPTION
Potential addition to https://github.com/enactjs/cli/pull/179

Alternative to the react-dev-utils TypeScript workaround which removes the MiniCssExtractPlugin usage in serving and whenever  `INLINE_STYLES` env var is set.  This is more in the `create-react-app` style, though may present issues with CSS order potentially (as CSS will be added to the dom in `<style>` tags dynamically, rather than everything collected into external `*.css` files and added as header stylesheet `<link>` tags).

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>