### PR TITLE
ENYO-5928: Ejected apps fail load Babel correctly

### DIFF
--- a/commands/eject.js
+++ b/commands/eject.js
@@ -21,6 +21,7 @@ const spawn = require('cross-spawn');
 
 const assets = [
 	{src: path.join(__dirname, '..', 'config'), dest: 'config'},
+	{src: path.join(__dirname, '..', 'config', 'jest'), dest: 'config/jest'},
 	{src: path.join(__dirname, '..', 'commands'), dest: 'scripts'}
 ];
 const internal = [

--- a/commands/eject.js
+++ b/commands/eject.js
@@ -36,7 +36,7 @@ const internal = [
 	'validate-npm-package-name'
 ];
 const enhanced = ['chalk', 'cross-spawn', 'filesize', 'fs-extra', 'minimist', 'strip-ansi'];
-const content = ['@babel/polyfill', 'react', 'react-dom'];
+const content = ['core-js', 'react', 'react-dom'];
 const bareDeps = {'cpy-cli': '^2.0.0', rimraf: '^2.6.2'};
 const bareTasks = {
 	serve: 'webpack-dev-server --hot --inline --env development --config config/webpack.config.js',
@@ -160,7 +160,6 @@ function configurePackage(bare) {
 	const enactCLI = new RegExp('enact (' + availScripts.join('|') + ')', 'g');
 	const eslintConfig = {extends: 'enact'};
 	const eslintIgnore = ['build/*', 'config/*', 'dist/*', 'node_modules/*', 'scripts/*'];
-	const babel = {extends: './config/.babelrc.js'};
 	const conflicts = [];
 
 	app.dependencies = app.dependencies || [];
@@ -217,14 +216,6 @@ function configurePackage(bare) {
 	app.eslintIgnore = app.eslintIgnore || [];
 	app.eslintIgnore = app.eslintIgnore.concat(eslintIgnore.filter(l => !app.eslintIgnore.includes(l)));
 	backupOld(['.eslintignore', '.eslintrc.js', '.eslintrc.yaml', '.eslintrc.yml', '.eslintrc.json', '.eslintrc']);
-
-	// Update Babel settings
-	console.log(`	Setting up ${chalk.cyan('Babel')} config in package.json`);
-	if (app.babel && JSON.stringify(app.babel) !== JSON.stringify(babel)) {
-		conflicts.push(chalk.cyan('Babel'));
-	}
-	app.babel = babel;
-	backupOld(['.babelrc', '.babelrc.js']);
 
 	// Sort the package.json output
 	['dependencies', 'devDependencies'].forEach(obj => {

--- a/commands/license.js
+++ b/commands/license.js
@@ -5,9 +5,8 @@ const checker = require('license-checker');
 const minimist = require('minimist');
 
 // The following modules reside in `@enact/cli` but end up in production builds of apps
-const enactCLIProdModules = ['@babel/core', '@babel/polyfill'].map(m =>
-	path.dirname(require.resolve(m + '/package.json'))
-);
+const pkgPathResolve = m => path.dirname(require.resolve(m + '/package.json'));
+const enactCLIProdModules = ['@babel/core', 'core-js'].map(pkgPathResolve);
 
 function displayHelp() {
 	let e = 'node ' + path.relative(process.cwd(), __filename);

--- a/commands/transpile.js
+++ b/commands/transpile.js
@@ -10,7 +10,7 @@ const LessPluginRi = require('resolution-independence');
 const {optionParser: app} = require('@enact/dev-utils');
 
 const blacklist = ['node_modules', 'build', 'dist', '.git', '.gitignore'];
-const babelrc = path.join(__dirname, '..', 'config', '.babelrc.js');
+const babelConfig = path.join(__dirname, '..', 'config', 'babel.config.js');
 const babelRename = {original: '^(\\.(?!.*\\bstyles\\b.*).*)\\.less$', replacement: '$1.css'};
 
 // Temporary until PLAT-72711, hardcode expected libraries to 24px base size
@@ -37,7 +37,7 @@ function displayHelp() {
 
 function transpile(src, dest, plugins) {
 	return new Promise((resolve, reject) => {
-		babel.transformFile(src, {extends: babelrc, plugins}, (err, result) => {
+		babel.transformFile(src, {extends: babelConfig, plugins}, (err, result) => {
 			if (err) {
 				reject(err);
 			} else {

--- a/config/.babelrc.js
+++ b/config/.babelrc.js
@@ -7,75 +7,79 @@
 
 const app = require('@enact/dev-utils').optionParser;
 
-const env = process.env.BABEL_ENV || process.env.NODE_ENV;
-const es5Standalone = process.env.ES5 && process.env.ES5 !== 'false';
+module.exports = function (api) {
+	const env = process.env.BABEL_ENV || process.env.NODE_ENV;
+	const es5Standalone = process.env.ES5 && process.env.ES5 !== 'false';
 
-module.exports = {
-	presets: [
-		[
-			'@babel/preset-env',
-			{
-				exclude: [
-					'transform-regenerator',
-					// Ignore web features since window and DOM is not available
-					// in a V8 snapshot blob.
-					// TODO: investigates ways to include but delay loading.
-					'web.dom-collections.for-each',
-					'web.dom-collections.iterator',
-					'web.immediate',
-					'web.queue-microtask',
-					'web.timers',
-					'web.url',
-					'web.url.to-json',
-					'web.url-search-params'
-				],
-				forceAllTransforms: es5Standalone,
-				useBuiltIns: 'entry',
-				corejs: 3,
-				modules: false
-			}
+	api.cache(() => env + es5Standalone);
+
+	return {
+		presets: [
+			[
+				'@babel/preset-env',
+				{
+					exclude: [
+						'transform-regenerator',
+						// Ignore web features since window and DOM is not available
+						// in a V8 snapshot blob.
+						// TODO: investigates ways to include but delay loading.
+						'web.dom-collections.for-each',
+						'web.dom-collections.iterator',
+						'web.immediate',
+						'web.queue-microtask',
+						'web.timers',
+						'web.url',
+						'web.url.to-json',
+						'web.url-search-params'
+					],
+					forceAllTransforms: es5Standalone,
+					useBuiltIns: 'entry',
+					corejs: 3,
+					modules: false
+				}
+			],
+			[
+				'@babel/preset-react',
+				{
+					// Adds component stack to warning messages
+					// Adds __self attribute to JSX which React will use for some warnings
+		 			development: env !== 'production' && !es5Standalone,
+					// Will use the native built-in instead of trying to polyfill
+					// behavior for any plugins that require one.
+					useBuiltIns: true
+				}
+			],
+			[
+				'@babel/preset-typescript'
+			]
 		],
-		[
-			'@babel/preset-react',
-			{
-				// Adds component stack to warning messages
-				// Adds __self attribute to JSX which React will use for some warnings
-	 			development: env !== 'production' && !es5Standalone,
-				// Will use the native built-in instead of trying to polyfill
-				// behavior for any plugins that require one.
-				useBuiltIns: true
-			}
-		],
-		[
-			'@babel/preset-typescript'
-		]
-	],
-	plugins: [
-		// Stage 0
-		//'@babel/plugin-proposal-function-bind',
+		plugins: [
+			// Stage 0
+			//'@babel/plugin-proposal-function-bind',
 
-		// Stage 1
-		'@babel/plugin-proposal-export-default-from',
-		//'@babel/plugin-proposal-logical-assignment-operators',
-		//['@babel/plugin-proposal-optional-chaining', { 'loose': false }],
-		//['@babel/plugin-proposal-pipeline-operator', { 'proposal': 'minimal' }],
-		//['@babel/plugin-proposal-nullish-coalescing-operator', { 'loose': false }],
-		//'@babel/plugin-proposal-do-expressions',
+			// Stage 1
+			'@babel/plugin-proposal-export-default-from',
+			//'@babel/plugin-proposal-logical-assignment-operators',
+			//['@babel/plugin-proposal-optional-chaining', { 'loose': false }],
+			//['@babel/plugin-proposal-pipeline-operator', { 'proposal': 'minimal' }],
+			//['@babel/plugin-proposal-nullish-coalescing-operator', { 'loose': false }],
+			//'@babel/plugin-proposal-do-expressions',
 
-		// Stage 2
-		//['@babel/plugin-proposal-decorators', { 'legacy': true }],
-		//'@babel/plugin-proposal-function-sent',
-		'@babel/plugin-proposal-export-namespace-from',
-		//'@babel/plugin-proposal-numeric-separator',
-		//'@babel/plugin-proposal-throw-expressions',
+			// Stage 2
+			//['@babel/plugin-proposal-decorators', { 'legacy': true }],
+			//'@babel/plugin-proposal-function-sent',
+			'@babel/plugin-proposal-export-namespace-from',
+			//'@babel/plugin-proposal-numeric-separator',
+			//'@babel/plugin-proposal-throw-expressions',
 
-		// Stage 3
-		'@babel/plugin-syntax-dynamic-import',
-		//'@babel/plugin-syntax-import-meta',
-		['@babel/plugin-proposal-class-properties', { 'loose': true }],
-		//'@babel/plugin-proposal-json-strings'
+			// Stage 3
+			'@babel/plugin-syntax-dynamic-import',
+			//'@babel/plugin-syntax-import-meta',
+			['@babel/plugin-proposal-class-properties', { 'loose': true }],
+			//'@babel/plugin-proposal-json-strings'
 
-		'dev-expression',
-		env === 'production' && !es5Standalone && '@babel/plugin-transform-react-inline-elements'
-	].filter(Boolean)
+			'dev-expression',
+			env === 'production' && !es5Standalone && '@babel/plugin-transform-react-inline-elements'
+		].filter(Boolean)
+	};
 };

--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -1,13 +1,11 @@
 /*
- *  .babelrc.js
+ *  babel.config.js
  *
  *  A Babel javascript configuration dynamically setup for Enact
  *  development environment on target platforms.
  */
 
-const app = require('@enact/dev-utils').optionParser;
-
-module.exports = function (api) {
+module.exports = function(api) {
 	const env = process.env.BABEL_ENV || process.env.NODE_ENV;
 	const es5Standalone = process.env.ES5 && process.env.ES5 !== 'false';
 
@@ -43,40 +41,38 @@ module.exports = function (api) {
 				{
 					// Adds component stack to warning messages
 					// Adds __self attribute to JSX which React will use for some warnings
-		 			development: env !== 'production' && !es5Standalone,
+					development: env !== 'production' && !es5Standalone,
 					// Will use the native built-in instead of trying to polyfill
 					// behavior for any plugins that require one.
 					useBuiltIns: true
 				}
 			],
-			[
-				'@babel/preset-typescript'
-			]
+			['@babel/preset-typescript']
 		],
 		plugins: [
 			// Stage 0
-			//'@babel/plugin-proposal-function-bind',
+			// '@babel/plugin-proposal-function-bind',
 
 			// Stage 1
 			'@babel/plugin-proposal-export-default-from',
-			//'@babel/plugin-proposal-logical-assignment-operators',
-			//['@babel/plugin-proposal-optional-chaining', { 'loose': false }],
-			//['@babel/plugin-proposal-pipeline-operator', { 'proposal': 'minimal' }],
-			//['@babel/plugin-proposal-nullish-coalescing-operator', { 'loose': false }],
-			//'@babel/plugin-proposal-do-expressions',
+			// '@babel/plugin-proposal-logical-assignment-operators',
+			// ['@babel/plugin-proposal-optional-chaining', { 'loose': false }],
+			// ['@babel/plugin-proposal-pipeline-operator', { 'proposal': 'minimal' }],
+			// ['@babel/plugin-proposal-nullish-coalescing-operator', { 'loose': false }],
+			// '@babel/plugin-proposal-do-expressions',
 
 			// Stage 2
-			//['@babel/plugin-proposal-decorators', { 'legacy': true }],
-			//'@babel/plugin-proposal-function-sent',
+			// ['@babel/plugin-proposal-decorators', { 'legacy': true }],
+			// '@babel/plugin-proposal-function-sent',
 			'@babel/plugin-proposal-export-namespace-from',
-			//'@babel/plugin-proposal-numeric-separator',
-			//'@babel/plugin-proposal-throw-expressions',
+			// '@babel/plugin-proposal-numeric-separator',
+			// '@babel/plugin-proposal-throw-expressions',
 
 			// Stage 3
 			'@babel/plugin-syntax-dynamic-import',
-			//'@babel/plugin-syntax-import-meta',
-			['@babel/plugin-proposal-class-properties', { 'loose': true }],
-			//'@babel/plugin-proposal-json-strings'
+			// '@babel/plugin-syntax-import-meta',
+			['@babel/plugin-proposal-class-properties', {loose: true}],
+			// '@babel/plugin-proposal-json-strings'
 
 			'dev-expression',
 			env === 'production' && !es5Standalone && '@babel/plugin-transform-react-inline-elements'

--- a/config/jest/babelTransform.js
+++ b/config/jest/babelTransform.js
@@ -13,7 +13,7 @@ const path = require('path');
 const babelJest = require('babel-jest');
 
 module.exports = babelJest.createTransformer({
-	extends: path.join(__dirname, '..', '.babelrc.js'),
+	extends: path.join(__dirname, '..', 'babel.config.js'),
 	plugins: [
 		require.resolve('@babel/plugin-transform-modules-commonjs'),
 		require.resolve('babel-plugin-dynamic-import-node')

--- a/config/jest/babelTransform.js
+++ b/config/jest/babelTransform.js
@@ -1,4 +1,3 @@
-// @remove-file-on-eject
 /**
  * Portions of this source code file are from create-react-app, used under the
  * following MIT license:

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -1,4 +1,3 @@
-// @remove-file-on-eject
 /**
  * Portions of this source code file are from create-react-app, used under the
  * following MIT license:

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -201,10 +201,8 @@ module.exports = function(env) {
 								{
 									loader: require.resolve('babel-loader'),
 									options: {
-										// @remove-on-eject-begin
-										extends: path.join(__dirname, '.babelrc.js'),
+										configFile: path.join(__dirname, 'babel.config.js'),
 										babelrc: false,
-										// @remove-on-eject-end
 										// This is a feature of `babel-loader` for webpack (not Babel itself).
 										// It enables caching results in ./node_modules/.cache/babel-loader/
 										// directory for faster rebuilds.

--- a/docs/ejecting-apps.md
+++ b/docs/ejecting-apps.md
@@ -32,8 +32,8 @@ my-app/
   node_modules/
   config/
     polyfills.js
-    babel-proxy.js
-    .babelrc.js
+    corejs-proxy.js
+    babel.config.js
     dotenv.js
     html-template.ejs
     webpack.config.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,17 +13,17 @@
       }
     },
     "@babel/core": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.3.4.tgz",
-      "integrity": "sha512-jRsuseXBo9pN197KnDwhhaaBzyZr2oIcLHHTt2oDdQrej5Qp57dCCJafWx5ivU8/alEYDpssYqv1MUqcxwQlrA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.3.tgz",
+      "integrity": "sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.3.4",
-        "@babel/helpers": "^7.2.0",
-        "@babel/parser": "^7.3.4",
-        "@babel/template": "^7.2.2",
-        "@babel/traverse": "^7.3.4",
-        "@babel/types": "^7.3.4",
+        "@babel/generator": "^7.4.0",
+        "@babel/helpers": "^7.4.3",
+        "@babel/parser": "^7.4.3",
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
+        "@babel/types": "^7.4.0",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
@@ -283,11 +283,11 @@
       }
     },
     "@babel/plugin-proposal-class-properties": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.2.0.tgz",
-      "integrity": "sha512-pdBj4Hvyt/L1LA0Vvm/Tkp9gNDGLIkSbX8IrYfWcoA5xUZIg8qjSOTChUSaCjYdvoMcB9y2bXVGNVZ5DH62CZg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.0.tgz",
+      "integrity": "sha512-t2ECPNOXsIeK1JxJNKmgbzQtoG27KIlVE61vTqX0DKR9E9sZlVVxWUtEW9D5FlZ8b8j7SBNCHY47GgPKCKlpPg==",
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.2.0",
+        "@babel/helper-create-class-features-plugin": "^7.4.0",
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
@@ -536,6 +536,14 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
+      "integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-transform-modules-amd": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.2.0.tgz",
@@ -546,11 +554,11 @@
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz",
-      "integrity": "sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.3.tgz",
+      "integrity": "sha512-sMP4JqOTbMJMimqsSZwYWsMjppD+KRyDIUVW91pd7td0dZKAvPmhCaxhOzkzLParKwgQc7bdL9UNv+rpJB0HfA==",
       "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-module-transforms": "^7.4.3",
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-simple-access": "^7.1.0"
       }
@@ -608,6 +616,14 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
+      "integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-transform-react-display-name": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
@@ -659,6 +675,14 @@
       "integrity": "sha512-kEzotPuOpv6/iSlHroCDydPkKYw7tiJGKlmYp6iJn4a6C/+b2FdttlJsLKYxolYHgotTJ5G5UY5h0qey5ka3+A==",
       "requires": {
         "regenerator-transform": "^0.13.4"
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
+      "integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -722,63 +746,59 @@
         "regexpu-core": "^4.5.4"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
-      "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
-      "requires": {
-        "core-js": "^2.5.7",
-        "regenerator-runtime": "^0.12.0"
-      }
-    },
     "@babel/preset-env": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.3.4.tgz",
-      "integrity": "sha512-2mwqfYMK8weA0g0uBKOt4FE3iEodiHy9/CW0b+nWXcbL+pGzLx8ESYc+j9IIxr6LTDHWKgPm71i9smo02bw+gA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.3.tgz",
+      "integrity": "sha512-FYbZdV12yHdJU5Z70cEg0f6lvtpZ8jFSDakTm7WXeJbLXh4R0ztGEu/SW7G1nJ2ZvKwDhz8YrbA84eYyprmGqw==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
         "@babel/plugin-proposal-json-strings": "^7.2.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.3.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.4.3",
         "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.2.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.4.0",
         "@babel/plugin-syntax-async-generators": "^7.2.0",
         "@babel/plugin-syntax-json-strings": "^7.2.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
         "@babel/plugin-transform-arrow-functions": "^7.2.0",
-        "@babel/plugin-transform-async-to-generator": "^7.3.4",
+        "@babel/plugin-transform-async-to-generator": "^7.4.0",
         "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-        "@babel/plugin-transform-block-scoping": "^7.3.4",
-        "@babel/plugin-transform-classes": "^7.3.4",
+        "@babel/plugin-transform-block-scoping": "^7.4.0",
+        "@babel/plugin-transform-classes": "^7.4.3",
         "@babel/plugin-transform-computed-properties": "^7.2.0",
-        "@babel/plugin-transform-destructuring": "^7.2.0",
-        "@babel/plugin-transform-dotall-regex": "^7.2.0",
+        "@babel/plugin-transform-destructuring": "^7.4.3",
+        "@babel/plugin-transform-dotall-regex": "^7.4.3",
         "@babel/plugin-transform-duplicate-keys": "^7.2.0",
         "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-        "@babel/plugin-transform-for-of": "^7.2.0",
-        "@babel/plugin-transform-function-name": "^7.2.0",
+        "@babel/plugin-transform-for-of": "^7.4.3",
+        "@babel/plugin-transform-function-name": "^7.4.3",
         "@babel/plugin-transform-literals": "^7.2.0",
+        "@babel/plugin-transform-member-expression-literals": "^7.2.0",
         "@babel/plugin-transform-modules-amd": "^7.2.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.2.0",
-        "@babel/plugin-transform-modules-systemjs": "^7.3.4",
+        "@babel/plugin-transform-modules-commonjs": "^7.4.3",
+        "@babel/plugin-transform-modules-systemjs": "^7.4.0",
         "@babel/plugin-transform-modules-umd": "^7.2.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.3.0",
-        "@babel/plugin-transform-new-target": "^7.0.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.4.2",
+        "@babel/plugin-transform-new-target": "^7.4.0",
         "@babel/plugin-transform-object-super": "^7.2.0",
-        "@babel/plugin-transform-parameters": "^7.2.0",
-        "@babel/plugin-transform-regenerator": "^7.3.4",
+        "@babel/plugin-transform-parameters": "^7.4.3",
+        "@babel/plugin-transform-property-literals": "^7.2.0",
+        "@babel/plugin-transform-regenerator": "^7.4.3",
+        "@babel/plugin-transform-reserved-words": "^7.2.0",
         "@babel/plugin-transform-shorthand-properties": "^7.2.0",
         "@babel/plugin-transform-spread": "^7.2.0",
         "@babel/plugin-transform-sticky-regex": "^7.2.0",
         "@babel/plugin-transform-template-literals": "^7.2.0",
         "@babel/plugin-transform-typeof-symbol": "^7.2.0",
-        "@babel/plugin-transform-unicode-regex": "^7.2.0",
-        "browserslist": "^4.3.4",
+        "@babel/plugin-transform-unicode-regex": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "browserslist": "^4.5.2",
+        "core-js-compat": "^3.0.0",
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
-        "semver": "^5.3.0"
+        "semver": "^5.5.0"
       },
       "dependencies": {
         "semver": {
@@ -882,6 +902,13 @@
         "tapable": "^1.1.0",
         "webpack-bundle-analyzer": "^3.0.2",
         "webpack-sources": "^1.2.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+        }
       }
     },
     "@enact/template-moonstone": {
@@ -2678,9 +2705,25 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.0.1.tgz",
+      "integrity": "sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew=="
+    },
+    "core-js-compat": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.0.1.tgz",
+      "integrity": "sha512-2pC3e+Ht/1/gD7Sim/sqzvRplMiRnFQVlPpDVaHtY9l7zZP7knamr3VRD6NyGfHd84MrDC0tAM9ulNxYMW0T3g==",
+      "requires": {
+        "browserslist": "^4.5.4",
+        "core-js": "3.0.1",
+        "core-js-pure": "3.0.1",
+        "semver": "^6.0.0"
+      }
+    },
+    "core-js-pure": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.0.1.tgz",
+      "integrity": "sha512-mSxeQ6IghKW3MoyF4cz19GJ1cMm7761ON+WObSyLfTu/Jn3x7w4NwNFnrZxgl4MTSvYYepVLNuRtlB4loMwJ5g=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4791,11 +4834,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4808,11 +4853,13 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -9728,11 +9775,6 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regenerator-transform": {
       "version": "0.13.4",


### PR DESCRIPTION
Fixes https://github.com/enactjs/cli/issues/182

* Renamed the `.babelrc.js` to `babel.config.js`, using the functional-export format (rather than basic object exports). This is the current preferred method. Updated any source file references to point new filepath.
* Makes the `babel.config.js` file standalone, explicitly set as the `configFile` in the Webpack `babel-loader`. As a result, the Babel `package.json` settings no longer need to be inject during eject process.
* Additionally fixed minor issues where Jest config files were not ejecting into `./config/` as they should have.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>