### PR TITLE
ENYO-5932: Disable sourcemaps when using inline styles to avoid async blob stylesheets.

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -68,7 +68,7 @@ module.exports = function(env) {
 			{
 				loader: require.resolve('css-loader'),
 				options: Object.assign(
-					{importLoaders: preProcessor ? 2 : 1, sourceMap: shouldUseSourceMap},
+					{importLoaders: preProcessor ? 2 : 1, sourceMap: !process.env.INLINE_STYLES},
 					cssLoaderOptions.modules && {getLocalIdent: getCSSModuleLocalIdent},
 					cssLoaderOptions
 				)
@@ -81,7 +81,7 @@ module.exports = function(env) {
 				options: {
 					// https://webpack.js.org/guides/migrating/#complex-options
 					ident: 'postcss',
-					sourceMap: shouldUseSourceMap,
+					sourceMap: !process.env.INLINE_STYLES && shouldUseSourceMap,
 					plugins: () =>
 						[
 							// Fix and adjust for known flexbox issues
@@ -117,7 +117,7 @@ module.exports = function(env) {
 			loader: require.resolve('less-loader'),
 			options: {
 				modifyVars: Object.assign({__DEV__: !isEnvProduction}, app.accent),
-				sourceMap: shouldUseSourceMap
+				sourceMap: !process.env.INLINE_STYLES && shouldUseSourceMap
 			}
 		});
 

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -50,6 +50,7 @@ module.exports = function(env) {
 	// on or off by setting the GENERATE_SOURCEMAP environment variable.
 	const GENERATE_SOURCEMAP = process.env.GENERATE_SOURCEMAP || (isEnvProduction ? 'false' : 'true');
 	const shouldUseSourceMap = GENERATE_SOURCEMAP !== 'false';
+	const shouldSourceMapStyles = !process.env.INLINE_STYLES && shouldUseSourceMap;
 
 	// common function to get style loaders
 	const getStyleLoaders = (cssLoaderOptions = {}, preProcessor) => {
@@ -68,7 +69,7 @@ module.exports = function(env) {
 			{
 				loader: require.resolve('css-loader'),
 				options: Object.assign(
-					{importLoaders: preProcessor ? 2 : 1, sourceMap: !process.env.INLINE_STYLES},
+					{importLoaders: preProcessor ? 2 : 1, sourceMap: shouldSourceMapStyles},
 					cssLoaderOptions.modules && {getLocalIdent: getCSSModuleLocalIdent},
 					cssLoaderOptions
 				)
@@ -81,7 +82,7 @@ module.exports = function(env) {
 				options: {
 					// https://webpack.js.org/guides/migrating/#complex-options
 					ident: 'postcss',
-					sourceMap: !process.env.INLINE_STYLES && shouldUseSourceMap,
+					sourceMap: shouldSourceMapStyles,
 					plugins: () =>
 						[
 							// Fix and adjust for known flexbox issues
@@ -117,7 +118,7 @@ module.exports = function(env) {
 			loader: require.resolve('less-loader'),
 			options: {
 				modifyVars: Object.assign({__DEV__: !isEnvProduction}, app.accent),
-				sourceMap: !process.env.INLINE_STYLES && shouldUseSourceMap
+				sourceMap: shouldSourceMapStyles
 			}
 		});
 


### PR DESCRIPTION
When env var `INLINE_STYLES` is set (such as during serving), disable stylesheet sourcemap generation.
This gets around an active issue with `style-loader` where when `sourceMaps` are enabled, the style loader attempts to add styles via Blob URLs rather than inline `<style>` tags. See https://github.com/webpack-contrib/style-loader/blob/81b4d188f373123d56c4e0ac2cd4554c8ed27a86/src/addStyles.js#L319 This can cause styles to load asynchronously affecting initial style-based metrics.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>