### PR TITLE
PLAT-77105: Resolve CLI serving compatibility with custom Chrome extension

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -270,9 +270,9 @@ module.exports = function(env) {
 			// Broadcast http server on the localhost, port 8080
 			host: '0.0.0.0',
 			port: 8080,
-			// By default WebpackDevServer serves physical files from current directory
+			// By default WebpackDevServer serves files from the root and public directories
 			// in addition to all the virtual build products that it serves from memory.
-			contentBase: path.resolve('./public'),
+			contentBase: [path.resolve('./public'), app.context],
 			// Any changes to files from `contentBase` should trigger a page reload.
 			watchContentBase: true,
 			// Reportedly, this avoids CPU overload on some systems.


### PR DESCRIPTION
Resolve CLI serving compatibility with project-relative components for external tools.
Adds root directory to host as a content base along with `./public` subdirectory. Allows XHR requests to fallback from `/public` to `./`.

For reference, we used to solely use root as the content base, but altered to just `./public` (without fallback) as of https://github.com/enactjs/cli/pull/176

Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>