### PR TITLE
PLAT-78524: Narrow polyfill support to only stable features

### DIFF
--- a/config/corejs-proxy.js
+++ b/config/corejs-proxy.js
@@ -8,8 +8,8 @@
  *  transforms.
  */
 
-// Apply core-js polyfills
-require('core-js');
+// Apply stable core-js polyfills
+require('core-js/stable');
 
 // Manually set global._babelPolyfill as a flag to avoid multiple loading.
 // Uses 'babelPolyfill' name for historical meaning and external/backward


### PR DESCRIPTION
Switch from polyfilling all needed features to polyfilling only stable features (not in draft state/stage 0-3).

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>