### PR TITLE
PLAT-77105: Resolve CLI serving compatibility with custom Chrome extension

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -270,9 +270,9 @@ module.exports = function(env) {
 			// Broadcast http server on the localhost, port 8080
 			host: '0.0.0.0',
 			port: 8080,
-			// By default WebpackDevServer serves physical files from current directory
+			// By default WebpackDevServer serves files from public and __mocks__ directories
 			// in addition to all the virtual build products that it serves from memory.
-			contentBase: path.resolve('./public'),
+			contentBase: [path.resolve('./public'), path.resolve('./__mocks__')],
 			// Any changes to files from `contentBase` should trigger a page reload.
 			watchContentBase: true,
 			// Reportedly, this avoids CPU overload on some systems.


### PR DESCRIPTION
Resolve CLI serving compatibility with mock data for external tools.
Adds `./__mocks__` directory as a content base along with the current `./public` directory. Allows XHR requests to fallback for mock data files within `./__mocks__, while keeping out of public asset files.

Preferred alternative to https://github.com/enactjs/cli/pull/185

Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>