### PR TITLE
PLAT-76285: Enhanced React Hooks support in tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You would need to install an ESLint plugin for your editor first.
 Then, you will need to install some packages *globally*:
 
 ```sh
-npm install -g eslint eslint-plugin-react eslint-plugin-babel babel-eslint eslint-plugin-jest eslint-plugin-enact eslint-config-enact
+npm install -g eslint eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel babel-eslint eslint-plugin-jest eslint-plugin-enact eslint-config-enact
 ```
 
 ## Copyright and License Information

--- a/package-lock.json
+++ b/package-lock.json
@@ -4184,6 +4184,11 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz",
+      "integrity": "sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag=="
+    },
     "eslint-rule-composer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint-plugin-enact": "0.1.3",
     "eslint-plugin-jest": "22.4.1",
     "eslint-plugin-react": "7.12.4",
+    "eslint-plugin-react-hooks": "1.6.0",
     "expose-loader": "0.7.5",
     "file-loader": "3.0.1",
     "filesize": "4.1.2",


### PR DESCRIPTION
Requires https://github.com/enactjs/eslint-config-enact/pull/27 merged and published to NPM. At which point this PR can update the `eslint-config-enact` dependency.

Adds `eslint-plugin-react-hooks` dependency and will update `eslint-config-enact` package, which adds the `react-hooks/exhaustive-deps` warning and `react-hooks/rules-of-hooks` error rules.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>