### PR TITLE
PLAT-81105: Undetermined RI value can result in Infinity rem values

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -102,7 +102,7 @@ module.exports = function(env) {
 								features: {'custom-properties': false}
 							}),
 							// Resolution indepedence support
-							app.ri && require('postcss-resolution-independence')(app.ri)
+							app.ri !== false && require('postcss-resolution-independence')(app.ri)
 						].filter(Boolean)
 				}
 			}


### PR DESCRIPTION
To be used with: https://github.com/enactjs/dev-utils/pull/42

Allows `undefined`/`null` values for resolution independence settings to allow default options to be used. However, still guard against an explicit `false`value as a method of disabling use of the POSTCSS plugin.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>