### PR TITLE
PLAT-80499: Transition to external iLib NPM module

### DIFF
--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -20,7 +20,7 @@ process.env.BROWSERSLIST = 'current node';
 const pkg = packageRoot();
 const globals = {
 	__DEV__: true,
-	ILIB_BASE_PATH: 'node_modules/@enact/i18n/ilib',
+	ILIB_BASE_PATH: 'node_modules/@enact/i18n/node_modules/ilib-webos-tv',
 	ILIB_RESOURCES_PATH: 'resources',
 	ILIB_CACHE_ID: new Date().getTime() + '',
 	ILIB_MOONSTONE_PATH: 'node_modules/@enact/moonstone/resources'

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -8,6 +8,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+const fs = require('fs');
 const path = require('path');
 const {packageRoot} = require('@enact/dev-utils');
 
@@ -18,9 +19,10 @@ process.env.PUBLIC_URL = '';
 process.env.BROWSERSLIST = 'current node';
 
 const pkg = packageRoot();
+const iLibPkgs = ['node_modules/ilib-webos-tv', 'node_modules/@enact/i18n/node_modules/ilib-webos-tv'];
 const globals = {
 	__DEV__: true,
-	ILIB_BASE_PATH: 'node_modules/@enact/i18n/node_modules/ilib-webos-tv',
+	ILIB_BASE_PATH: iLibPkgs.find(f => fs.existsSync(path.join(pkg.path, f))),
 	ILIB_RESOURCES_PATH: 'resources',
 	ILIB_CACHE_ID: new Date().getTime() + '',
 	ILIB_MOONSTONE_PATH: 'node_modules/@enact/moonstone/resources'
@@ -29,8 +31,6 @@ const globals = {
 if (pkg.meta.name === '@enact/moonstone') {
 	globals.ILIB_MOONSTONE_PATH = 'resources';
 	globals.ILIB_RESOURCES_PATH = '_resources_';
-} else if (pkg.meta.name === '@enact/i18n') {
-	globals.ILIB_BASE_PATH = 'ilib';
 }
 
 const ignorePatterns = [
@@ -67,8 +67,9 @@ module.exports = {
 	moduleNameMapper: {
 		'^.+\\.module\\.(css|less)$': require.resolve('identity-obj-proxy'),
 		'^enzyme$': require.resolve('enzyme'),
-		'^ilib$': path.join(pkg.path, globals.ILIB_BASE_PATH, 'lib', 'ilib.js'),
-		'^ilib[/\\\\](.*)$': path.join(pkg.path, globals.ILIB_BASE_PATH, 'lib', '$1')
+		'^ilib$': path.join(pkg.path, 'node_modules', '@enact', 'i18n', 'src', 'index.js'),
+		'^ilib[/](.*)$': path.join(pkg.path, globals.ILIB_BASE_PATH, '$1'),
+		'^@enact[/]i18n[/]ilib[/](.*)$': path.join(pkg.path, globals.ILIB_BASE_PATH, '$1')
 	},
 	moduleFileExtensions: ['js', 'jsx', 'json', 'ts', 'tsx'],
 	globals

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -19,12 +19,7 @@ process.env.PUBLIC_URL = '';
 process.env.BROWSERSLIST = 'current node';
 
 const pkg = packageRoot();
-const iLibDirs = [
-	'node_modules/ilib',
-	'node_modules/@enact/i18n/node_modules/ilib',
-	'node_modules/@enact/i18n/ilib',
-	'ilib'
-];
+const iLibDirs = ['node_modules/ilib', 'node_modules/@enact/i18n/ilib', 'ilib'];
 const globals = {
 	__DEV__: true,
 	ILIB_BASE_PATH: iLibDirs.find(f => fs.existsSync(path.join(pkg.path, f))) || iLibDirs[0],

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -19,7 +19,7 @@ process.env.PUBLIC_URL = '';
 process.env.BROWSERSLIST = 'current node';
 
 const pkg = packageRoot();
-const iLibPkgs = ['node_modules/ilib-webos-tv', 'node_modules/@enact/i18n/node_modules/ilib-webos-tv'];
+const iLibPkgs = ['node_modules/ilib', 'node_modules/@enact/i18n/node_modules/ilib'];
 const globals = {
 	__DEV__: true,
 	ILIB_BASE_PATH: iLibPkgs.find(f => fs.existsSync(path.join(pkg.path, f))) || iLibPkgs[0],
@@ -67,8 +67,7 @@ module.exports = {
 	moduleNameMapper: {
 		'^.+\\.module\\.(css|less)$': require.resolve('identity-obj-proxy'),
 		'^enzyme$': require.resolve('enzyme'),
-		'^ilib$': path.join(pkg.path, 'node_modules', '@enact', 'i18n', 'src', 'index.js'),
-		'^ilib[/](.*)$': path.join(pkg.path, globals.ILIB_BASE_PATH, '$1'),
+		// Backward compatibility for old iLib location
 		'^@enact[/]i18n[/]ilib[/](.*)$': path.join(pkg.path, globals.ILIB_BASE_PATH, '$1')
 	},
 	moduleFileExtensions: ['js', 'jsx', 'json', 'ts', 'tsx'],

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -22,7 +22,7 @@ const pkg = packageRoot();
 const iLibPkgs = ['node_modules/ilib-webos-tv', 'node_modules/@enact/i18n/node_modules/ilib-webos-tv'];
 const globals = {
 	__DEV__: true,
-	ILIB_BASE_PATH: iLibPkgs.find(f => fs.existsSync(path.join(pkg.path, f))),
+	ILIB_BASE_PATH: iLibPkgs.find(f => fs.existsSync(path.join(pkg.path, f))) || iLibPkgs[0],
 	ILIB_RESOURCES_PATH: 'resources',
 	ILIB_CACHE_ID: new Date().getTime() + '',
 	ILIB_MOONSTONE_PATH: 'node_modules/@enact/moonstone/resources'

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -19,7 +19,7 @@ process.env.PUBLIC_URL = '';
 process.env.BROWSERSLIST = 'current node';
 
 const pkg = packageRoot();
-const iLibDirs = ['node_modules/ilib', 'node_modules/@enact/i18n/ilib', 'ilib'];
+const iLibDirs = ['node_modules/@enact/i18n/ilib', 'node_modules/ilib', 'ilib'];
 const globals = {
 	__DEV__: true,
 	ILIB_BASE_PATH: iLibDirs.find(f => fs.existsSync(path.join(pkg.path, f))) || iLibDirs[0],

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -19,10 +19,15 @@ process.env.PUBLIC_URL = '';
 process.env.BROWSERSLIST = 'current node';
 
 const pkg = packageRoot();
-const iLibPkgs = ['node_modules/ilib', 'node_modules/@enact/i18n/node_modules/ilib'];
+const iLibDirs = [
+	'node_modules/ilib',
+	'node_modules/@enact/i18n/node_modules/ilib',
+	'node_modules/@enact/i18n/ilib',
+	'ilib'
+];
 const globals = {
 	__DEV__: true,
-	ILIB_BASE_PATH: iLibPkgs.find(f => fs.existsSync(path.join(pkg.path, f))) || iLibPkgs[0],
+	ILIB_BASE_PATH: iLibDirs.find(f => fs.existsSync(path.join(pkg.path, f))) || iLibDirs[0],
 	ILIB_RESOURCES_PATH: 'resources',
 	ILIB_CACHE_ID: new Date().getTime() + '',
 	ILIB_MOONSTONE_PATH: 'node_modules/@enact/moonstone/resources'
@@ -67,7 +72,9 @@ module.exports = {
 	moduleNameMapper: {
 		'^.+\\.module\\.(css|less)$': require.resolve('identity-obj-proxy'),
 		'^enzyme$': require.resolve('enzyme'),
-		// Backward compatibility for old iLib location
+		// Backward compatibility for new iLib location with old Enact
+		'^ilib[/](.*)$': path.join(pkg.path, globals.ILIB_BASE_PATH, '$1'),
+		// Backward compatibility for old iLib location with new Enact
 		'^@enact[/]i18n[/]ilib[/](.*)$': path.join(pkg.path, globals.ILIB_BASE_PATH, '$1')
 	},
 	moduleFileExtensions: ['js', 'jsx', 'json', 'ts', 'tsx'],

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -22,7 +22,7 @@ const pkg = packageRoot();
 const iLibDirs = ['node_modules/@enact/i18n/ilib', 'node_modules/ilib', 'ilib'];
 const globals = {
 	__DEV__: true,
-	ILIB_BASE_PATH: iLibDirs.find(f => fs.existsSync(path.join(pkg.path, f))) || iLibDirs[0],
+	ILIB_BASE_PATH: iLibDirs.find(f => fs.existsSync(path.join(pkg.path, f))) || iLibDirs[1],
 	ILIB_RESOURCES_PATH: 'resources',
 	ILIB_CACHE_ID: new Date().getTime() + '',
 	ILIB_MOONSTONE_PATH: 'node_modules/@enact/moonstone/resources'

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -156,7 +156,7 @@ module.exports = function(env) {
 			modules: [path.resolve('./node_modules'), 'node_modules'],
 			alias: {
 				// Support ilib shorthand alias for ilib modules
-				ilib: '@enact/i18n/ilib/lib'
+				ilib: '@enact/i18n/node_modules/ilib-webos-tv/lib'
 			}
 		},
 		// @remove-on-eject-begin

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -36,6 +36,11 @@ module.exports = function(env) {
 	// Load applicable .env files into environment variables.
 	require('./dotenv').load(app.context);
 
+	// Determine dynamic iLib location for aliasing
+	const iLib = ['ilib-webos-tv', '@enact/i18n/node_modules/ilib-webos-tv'].find(f =>
+		fs.existsSync(path.join(app.context, 'node_modules', f))
+	);
+
 	// Sets the browserslist default fallback set of browsers to the Enact default browser support list.
 	app.setEnactTargetsAsDefault();
 
@@ -156,7 +161,9 @@ module.exports = function(env) {
 			modules: [path.resolve('./node_modules'), 'node_modules'],
 			alias: {
 				// Support ilib shorthand alias for ilib modules
-				ilib: '@enact/i18n/node_modules/ilib-webos-tv/lib'
+				ilib$: '@enact/i18n',
+				ilib: iLib,
+				'@enact/i18n/ilib': iLib
 			}
 		},
 		// @remove-on-eject-begin

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -36,11 +36,6 @@ module.exports = function(env) {
 	// Load applicable .env files into environment variables.
 	require('./dotenv').load(app.context);
 
-	// Determine dynamic iLib location for aliasing
-	const iLib = ['ilib', '@enact/i18n/node_modules/ilib'].find(f =>
-		fs.existsSync(path.join(app.context, 'node_modules', f))
-	);
-
 	// Sets the browserslist default fallback set of browsers to the Enact default browser support list.
 	app.setEnactTargetsAsDefault();
 
@@ -161,7 +156,9 @@ module.exports = function(env) {
 			modules: [path.resolve('./node_modules'), 'node_modules'],
 			// Backward compatibility for apps using new ilib references with old Enact
 			// and old apps referencing old iLib location with new Enact
-			alias: !iLib ? {ilib: '@enact/i18n/ilib'} : {'@enact/i18n/ilib': iLib}
+			alias: !fs.existsSync(path.join(app.context, 'node_modules', 'ilib'))
+				? {ilib: '@enact/i18n/ilib'}
+				: {'@enact/i18n/ilib': 'ilib'}
 		},
 		// @remove-on-eject-begin
 		// Resolve loaders (webpack plugins for CSS, images, transpilation) from the

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -159,10 +159,9 @@ module.exports = function(env) {
 			extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
 			// Allows us to specify paths to check for module resolving.
 			modules: [path.resolve('./node_modules'), 'node_modules'],
-			alias: {
-				// Backward compatibility for old iLib location
-				'@enact/i18n/ilib': iLib
-			}
+			// Backward compatibility for apps using new ilib references with old Enact
+			// and old apps referencing old iLib location with new Enact
+			alias: Object.assign({}, !iLib ? {ilib: '@enact/i18n/ilib'} : {'@enact/i18n/ilib': iLib})
 		},
 		// @remove-on-eject-begin
 		// Resolve loaders (webpack plugins for CSS, images, transpilation) from the

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -37,7 +37,7 @@ module.exports = function(env) {
 	require('./dotenv').load(app.context);
 
 	// Determine dynamic iLib location for aliasing
-	const iLib = ['ilib-webos-tv', '@enact/i18n/node_modules/ilib-webos-tv'].find(f =>
+	const iLib = ['ilib', '@enact/i18n/node_modules/ilib'].find(f =>
 		fs.existsSync(path.join(app.context, 'node_modules', f))
 	);
 
@@ -160,9 +160,7 @@ module.exports = function(env) {
 			// Allows us to specify paths to check for module resolving.
 			modules: [path.resolve('./node_modules'), 'node_modules'],
 			alias: {
-				// Support ilib shorthand alias for ilib modules
-				ilib$: '@enact/i18n',
-				ilib: iLib,
+				// Backward compatibility for old iLib location
 				'@enact/i18n/ilib': iLib
 			}
 		},

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -161,7 +161,7 @@ module.exports = function(env) {
 			modules: [path.resolve('./node_modules'), 'node_modules'],
 			// Backward compatibility for apps using new ilib references with old Enact
 			// and old apps referencing old iLib location with new Enact
-			alias: Object.assign({}, !iLib ? {ilib: '@enact/i18n/ilib'} : {'@enact/i18n/ilib': iLib})
+			alias: !iLib ? {ilib: '@enact/i18n/ilib'} : {'@enact/i18n/ilib': iLib}
 		},
 		// @remove-on-eject-begin
 		// Resolve loaders (webpack plugins for CSS, images, transpilation) from the


### PR DESCRIPTION
Requires: https://github.com/enactjs/dev-utils/pull/44
Once that and https://github.com/enactjs/templates/pull/11 are merged, this PR can be updated for their new dependency releases.

Updates the Webpack and Jest configs for the new iLib location, along with temporary backwards-compatibility alias support so `@enact/i18n/ilib/...` imports/require statements still work (allowing app devs time to update).

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>