### PR TITLE
ENYO-6134: Int8Array.prototype.toLocaleString invocation breaks snapshot

### DIFF
--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -28,7 +28,8 @@ module.exports = function(api) {
 						'web.timers',
 						'web.url',
 						'web.url.to-json',
-						'web.url-search-params'
+						'web.url-search-params',
+						'es.typed-array.to-locale-string'
 					],
 					forceAllTransforms: es5Standalone,
 					useBuiltIns: 'entry',

--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -28,8 +28,7 @@ module.exports = function(api) {
 						'web.timers',
 						'web.url',
 						'web.url.to-json',
-						'web.url-search-params',
-						'es.typed-array.to-locale-string'
+						'web.url-search-params'
 					],
 					forceAllTransforms: es5Standalone,
 					useBuiltIns: 'entry',

--- a/config/polyfills.js
+++ b/config/polyfills.js
@@ -9,12 +9,18 @@ if (!global.skipPolyfills && !global._babelPolyfill) {
 	// Temporarily remap [Array].toLocaleString to [Array].toString.
 	// Fixes an issue with loading the polyfills within the v8 snapshot environment
 	// where toLocaleString() within the TypedArray polyfills causes snapshot failure.
-	var origToLocaleString = Array.prototype.toLocaleString;
+	var origToLocaleString = Array.prototype.toLocaleString,
+		origTypedToLocaleString;
 	Array.prototype.toLocaleString = Array.prototype.toString;
+	if (global.Int8Array && Int8Array.prototype) {
+		origTypedToLocaleString = Int8Array.prototype.toLocaleString;
+		Int8Array.prototype.toLocaleString = Int8Array.prototype.toString;
+	}
 
 	// Apply core-js polyfills
 	require('./corejs-proxy');
 
 	// Restore real [Array].toLocaleString for runtime usage.
-	Array.prototype.toLocaleString = origToLocaleString;
+	if (origToLocaleString) Array.prototype.toLocaleString = origToLocaleString;
+	if (origTypedToLocaleString) Int8Array.prototype.toLocaleString = origTypedToLocaleString;
 }

--- a/config/polyfills.js
+++ b/config/polyfills.js
@@ -12,7 +12,7 @@ if (!global.skipPolyfills && !global._babelPolyfill) {
 	var origToLocaleString = Array.prototype.toLocaleString,
 		origTypedToLocaleString;
 	Array.prototype.toLocaleString = Array.prototype.toString;
-	if (global.Int8Array && Int8Array.prototype) {
+	if (global.Int8Array && Int8Array.prototype.toLocaleString) {
 		origTypedToLocaleString = Int8Array.prototype.toLocaleString;
 		Int8Array.prototype.toLocaleString = Int8Array.prototype.toString;
 	}


### PR DESCRIPTION
`es.typed-array.to-locale-string` calls `Int8Array.prototype.toLocaleString` as part of its implementation/checking. This breaks snapshotting, similar to how `Array.prototype.toLocaleString` would break snapshot.

If an implementation of `Int8Array.prototype.toLocaleString` exists, swap it with `Int8Array.prototype.toString` when `core-js@3` is being applied to ensure the native function doesn't execute and break the snapshot.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>