### PR TITLE
Add animate support for tests

### DIFF
--- a/config/jest/setupTests.js
+++ b/config/jest/setupTests.js
@@ -84,3 +84,17 @@ class ILibXHR extends XHR {
 	}
 }
 global.XMLHttpRequest = ILibXHR;
+
+global.Element.prototype.animate = jest.fn().mockImplementation(() => {
+	const animation = {
+		onfinish: null,
+		cancel: () => {
+			if (animation.onfinish) animation.onfinish();
+		},
+		finish: () => {
+			if (animation.onfinish) animation.onfinish();
+		}
+	};
+
+	return animation;
+});


### PR DESCRIPTION
Adds `.animate()` support for tests that will fail due to https://github.com/enactjs/enact/pull/2475

Enact-DCO-1.1-Signed-off-by: Jeremy Thomas <jeremy.thomas@lge.com>