### PR TITLE
ENYO-6163: Jest tests fail to load dotenv files

### DIFF
--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -12,12 +12,6 @@ const fs = require('fs');
 const path = require('path');
 const {packageRoot} = require('@enact/dev-utils');
 
-// Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'test';
-process.env.NODE_ENV = 'test';
-process.env.PUBLIC_URL = '';
-process.env.BROWSERSLIST = 'current node';
-
 const pkg = packageRoot();
 const iLibDirs = ['node_modules/@enact/i18n/ilib', 'node_modules/ilib', 'ilib'];
 const globals = {
@@ -40,6 +34,15 @@ const ignorePatterns = [
 	'<rootDir>/(.*/)*build/',
 	'<rootDir>/(.*/)*dist/'
 ];
+
+// Setup env var to signify a testing environment
+process.env.BABEL_ENV = 'test';
+process.env.NODE_ENV = 'test';
+process.env.PUBLIC_URL = '';
+process.env.BROWSERSLIST = 'current node';
+
+// Load applicable .env files into environment variables.
+require('../dotenv').load(pkg.path);
 
 module.exports = {
 	collectCoverageFrom: ['**/*.{js,jsx,ts,tsx}', '!**/*.d.ts'],


### PR DESCRIPTION
Jest tests weren't loading project `.env` files like they should have been.  This PR adds dotenv loading to the Jest config to ensure all environment variables are present, like in our webpack builds.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>