### PR TITLE
PLAT-97856: Figure out unit testing with hooks

### DIFF
--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -76,6 +76,7 @@ module.exports = {
 	moduleNameMapper: {
 		'^.+\\.module\\.(css|less)$': require.resolve('identity-obj-proxy'),
 		'^enzyme$': require.resolve('enzyme'),
+		'^react$': require.resolve('react'),
 		// Backward compatibility for new iLib location with old Enact
 		'^ilib[/](.*)$': path.join(app.context, globals.ILIB_BASE_PATH, '$1'),
 		// Backward compatibility for old iLib location with new Enact


### PR DESCRIPTION
Redirect Jest requests for React library to use internal copy of React. This falls in-line with Enzyme usage.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>