### PR TITLE
PLAT-99377: Narrow unit test and transpile content to skip samples,…

### DIFF
--- a/commands/transpile.js
+++ b/commands/transpile.js
@@ -9,7 +9,7 @@ const minimist = require('minimist');
 const LessPluginRi = require('resolution-independence');
 const {optionParser: app} = require('@enact/dev-utils');
 
-const blacklist = ['node_modules', 'build', 'dist', '.git', '.gitignore'];
+const blacklist = ['node_modules', 'build', 'dist', 'docs', '.git', '.gitignore', 'samples', 'tests'];
 const babelConfig = path.join(__dirname, '..', 'config', 'babel.config.js');
 const babelRename = {original: '^(\\.(?!.*\\bstyles\\b.*).*)\\.less$', replacement: '$1.css'};
 

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -38,7 +38,11 @@ const ignorePatterns = [
 	'/node_modules/',
 	'<rootDir>/(.*/)*coverage/',
 	'<rootDir>/(.*/)*build/',
-	'<rootDir>/(.*/)*dist/'
+	'<rootDir>/(.*/)*dist/',
+	'<rootDir>/(.*/)*docs/',
+	'<rootDir>/(.*/)*samples/',
+	'<rootDir>/(.*/)*tests/screenshot/',
+	'<rootDir>/(.*/)*tests/ui/'
 ];
 
 // Setup env var to signify a testing environment


### PR DESCRIPTION
…screenshot tests, ui tests, and docs.

* Updates unit test detection to skip the new areas (ui tests, screenshot tests, samples) along with docs, when scanning for test specs.
* Updates the transpile blacklist to included the root samples, tests, and docs directories when transpiling a library for publishing.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>