### PR TITLE
PLAT-99524: Support simplified install/link process for theme ui repos

### DIFF
--- a/bin/enact.js
+++ b/bin/enact.js
@@ -55,6 +55,7 @@ if (process.argv.indexOf('-v') >= 0 || process.argv.indexOf('--version') >= 0) {
 	switch (command) {
 		case 'create':
 		case 'link':
+		case 'bootstrap':
 		case 'serve':
 		case 'transpile':
 		case 'pack':
@@ -76,6 +77,7 @@ if (process.argv.indexOf('-v') >= 0 || process.argv.indexOf('--version') >= 0) {
 			console.log('  Commands');
 			console.log('    create            Create a new project');
 			console.log('    link              Link @enact dependencies');
+			console.log('    bootstrap         Install and link dependencies');
 			console.log('    serve             Development server');
 			console.log('    pack              Bundle source code');
 			console.log('    test              Test specs runner');

--- a/commands/bootstrap.js
+++ b/commands/bootstrap.js
@@ -1,0 +1,78 @@
+// @remove-file-on-eject
+const path = require('path');
+const chalk = require('chalk');
+const spawn = require('cross-spawn');
+const fs = require('fs-extra');
+const minimist = require('minimist');
+const packageRoot = require('@enact/dev-utils').packageRoot;
+const link = require('./link').api;
+
+function displayHelp() {
+	let e = 'node ' + path.relative(process.cwd(), __filename);
+	if (require.main !== module) e = 'enact bootstrap';
+
+	console.log('  Usage');
+	console.log(`    ${e} [options]`);
+	console.log();
+	console.log('  Options');
+	console.log('    --loglevel        NPM log level to output');
+	console.log('    --verbose         Verbose output logging');
+	console.log('    -v, --version     Display version information');
+	console.log('    -h, --help        Display help information');
+	console.log();
+	process.exit(0);
+}
+
+function npmExec(args, cwd = process.cwd(), loglevel) {
+	return new Promise((resolve, reject) => {
+		if (loglevel) args.unshift('--loglevel', loglevel);
+		const child = spawn('npm', args, {stdio: 'inherit', cwd});
+		child.on('close', code => {
+			if (code !== 0) {
+				reject(new Error('Failed to ' + args[args.length - 1] + ': ' + path.basename(cwd)));
+			} else {
+				resolve();
+			}
+		});
+	});
+}
+
+function api({cwd = process.cwd(), loglevel, verbose = false} = {}) {
+	const pkg = packageRoot(cwd);
+	const scripts = pkg.meta.scripts || {};
+
+	if (verbose) loglevel = 'verbose';
+
+	if (scripts.bootstrap && scripts.bootstrap !== 'enact bootstrap') {
+		return npmExec(['run', 'bootstrap'], pkg.path, loglevel);
+	} else {
+		return npmExec(['install'], pkg.path, loglevel)
+			.then(() => link({cwd: pkg.path, loglevel, verbose}))
+			.then(() => {
+				const samples = path.join(pkg.path, 'samples');
+				if (fs.existsSync(samples)) {
+					return fs
+						.readdirSync(samples)
+						.map(p => path.join(samples, p))
+						.filter(p => fs.existsSync(path.join(p, 'package.json')))
+						.reduce((result, p) => result.then(api({cwd: p, loglevel, verbose})), Promise.resolve());
+				}
+			});
+	}
+}
+
+function cli(args) {
+	const opts = minimist(args, {
+		boolean: ['verbose', 'help'],
+		string: ['loglevel'],
+		alias: {h: 'help'}
+	});
+	if (opts.help) displayHelp();
+
+	api(opts).catch(err => {
+		console.error(chalk.red('ERROR: ') + err.message);
+		process.exit(1);
+	});
+}
+
+module.exports = {api, cli};

--- a/commands/link.js
+++ b/commands/link.js
@@ -14,6 +14,7 @@ function displayHelp() {
 	console.log(`    ${e} [options]`);
 	console.log();
 	console.log('  Options');
+	console.log('    --loglevel        NPM log level to output');
 	console.log('    --verbose         Verbose output logging');
 	console.log('    -v, --version     Display version information');
 	console.log('    -h, --help        Display help information');
@@ -21,12 +22,12 @@ function displayHelp() {
 	process.exit(0);
 }
 
-function globalModules() {
+function globalModules(cwd) {
 	return new Promise(resolve => {
 		let prefix = '';
 		const proc = spawn('npm', ['config', 'get', 'prefix', '-g'], {
 			stdio: 'pipe',
-			cwd: process.cwd(),
+			cwd,
 			env: process.env
 		});
 		proc.stdout.on('data', data => {
@@ -44,13 +45,13 @@ function globalModules() {
 	});
 }
 
-function api({verbose = false} = {}) {
-	const linkArgs = ['--loglevel', verbose ? 'verbose' : 'error', 'link'];
-	const pkg = packageRoot();
+function api({cwd = process.cwd(), loglevel = 'error', verbose = false} = {}) {
+	const linkArgs = ['--loglevel', verbose ? 'verbose' : loglevel, 'link'];
+	const pkg = packageRoot(cwd);
 	let enact = Object.keys(pkg.meta.dependencies || {}).concat(Object.keys(pkg.meta.devDependencies || {}));
 	enact = enact.filter(d => d.startsWith('@enact/')).map(d => d.replace('@enact/', ''));
 
-	return globalModules().then(globalDir => {
+	return globalModules(cwd).then(globalDir => {
 		return new Promise((resolve, reject) => {
 			const missing = [];
 			for (let i = 0; i < enact.length; i++) {
@@ -66,7 +67,7 @@ function api({verbose = false} = {}) {
 			} else if (missing.length === enact.length) {
 				reject(new Error('Enact global modules not found. Ensure they are linked correctly.'));
 			} else {
-				const proc = spawn('npm', linkArgs, {stdio: 'inherit', cwd: process.cwd()});
+				const proc = spawn('npm', linkArgs, {stdio: 'inherit', cwd});
 				proc.on('close', code => {
 					if (code !== 0) {
 						reject(new Error('"npm ' + linkArgs.join(' ') + '" failed'));
@@ -82,9 +83,12 @@ function api({verbose = false} = {}) {
 function cli(args) {
 	const opts = minimist(args, {
 		boolean: ['verbose', 'help'],
+		string: ['loglevel'],
 		alias: {h: 'help'}
 	});
 	if (opts.help) displayHelp();
+
+	if (opts._[0]) opts.cwd = opts._[0];
 
 	api(opts).catch(err => {
 		console.error(chalk.red('ERROR: ') + err.message);

--- a/commands/link.js
+++ b/commands/link.js
@@ -11,7 +11,11 @@ function displayHelp() {
 	if (require.main !== module) e = 'enact link';
 
 	console.log('  Usage');
-	console.log(`    ${e} [options]`);
+	console.log(`    ${e} [options] [target]`);
+	console.log();
+	console.log('  Arguments');
+	console.log('    target            Optional target file or directory');
+	console.log('                          (default: cwd)');
 	console.log();
 	console.log('  Options');
 	console.log('    --loglevel        NPM log level to output');

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ exportAPIs([
 	// List of commands to export via getters
 	'create',
 	'link',
+	'bootstrap',
 	'pack',
 	'serve',
 	'clean',


### PR DESCRIPTION
Adds a new `enact bootstrap` command which will:
* If a `bootstrap` NPM script is set, runs `np, run bootstrap`
* Otherwise will run `npm install` followed by `enact link`. Will then additionally repeat the process on any sampler/samples in `./samples` root project directory.

As a side effect of the this change, I've added optional argument to `enact link` to target directories for linking (defaults to command working directory).

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>