### PR TITLE
ENYO-6255: Added documentation on browser support and polyfills.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@
 
 ### template
 
-* Added support for `type` template property (used during project creation messages if `prepare` is not overriden). Defaults to `'app'`.
-* Fixed bug where template function parameters `defaultGenerator` and `type` could be accidentally overriden via command line arguments.
+* Added support for `type` template property (used during project creation messages if `prepare` is not overridden). Defaults to `'app'`.
+* Fixed bug where template function parameters `defaultGenerator` and `type` could be accidentally overridden via command line arguments.
 
 ## 2.4.1 (July 14, 2019)
 
@@ -37,20 +37,20 @@
 
 ## 2.3.1 (July 2, 2019)
 
-Fixed "Unexpected identifier" error on Node 6.x by using a compatible release of `find-cache-dir` subdependency.
+Fixed "Unexpected identifier" error on Node 6.x by using a compatible release of `find-cache-dir` sub-dependency.
 
 ## 2.3.0 (June 10, 2019)
 
 ### pack
 
 * Added React hook linting to help with adhering to the [rules of hooks](https://reactjs.org/docs/hooks-rules.html).
-* Updated polyfills to the `core-js/stable` stable featureset rather than all stable+draft polyfills.
+* Updated polyfills to the `core-js/stable` stable feature set rather than all stable+draft polyfills.
 * Updated default browserslist config from `last 2` stable versions of Chrome and Firefox to `last 5`.
 * Fixed build failing when prerendering for multiple locales.
 
 ### serve
 
-Added `./__mocks__` project directory as an optional allback directory for server asset contents (secondary to `./public`).
+Added `./__mocks__` project directory as an optional fallback directory for server asset contents (secondary to `./public`).
 
 ## 2.2.0 (April 28, 2019)
 
@@ -81,8 +81,8 @@ Updated all Babel dependencies up to 7.3.x to fix edge-case errors with `let` ke
 
 ### pack
 
-* Added support for a `public` directory, where static assets within are copied, at buildtime, to `./dist`.
-* Added support for `process.env.PUBLIC_URL` which is hardcode to `'.'`, for consistency with 3rd party standards.
+* Added support for a `public` directory, where static assets within are copied, at build time, to `./dist`.
+* Added support for `process.env.PUBLIC_URL` which is hardcoded to `'.'`, for consistency with 3rd party standards.
 
 ### serve
 
@@ -122,17 +122,17 @@ Updated all dependencies to latest releases and added support for TypeScript. In
 * Added support for stage-3 CSS via `postcss-preset-env`, with `custom-properties` temporarily disabled while a bug is being resolved.
 * Added support for `.env` fileformat to declare environment variables for parsing/app-embedding.
 * Added support for TypeScript compilation.
-* Added opt-in support for TypeScript typechecking at buildtime (via `typescript` app-side dependency).
+* Added opt-in support for TypeScript type checking at build time (via `typescript` app-side dependency).
 * Additional CSS optimization applied via `optimize-css-assets-webpack-plugin`.
 * Modified Babel configuration to use built-in APIs rather than transpiling mini re-implementations.
 * Modified CSS file handling to only process modular CSS on the `.module.css` extension.
-* Modified LESS file handling to be independence (only running LESS files through the LESS compiler), with `.module.lesas` file extension enabled modular context.
+* Modified LESS file handling to be independence (only running LESS files through the LESS compiler), with `.module.less` file extension enabled modular context.
 * Switched from `less-plugin-resolution-independence` to `postcss-plugin-resolution-independence` to apply to both LESS and CSS build chains.
 * Switched from `uglifyjs-webpack-plugin` to `terser-webpack-plugin` as Uglify is no longer actively developed.
 * Switched from `extract-text-webpack-plugin` to `mini-css-extract-plugin` for CSS content output.
 * Removed direct autoprefixer usage as `postcss-preset-env` contains embedded support.
 * Removed support for `.__DEV__` CSS class and replaced it with `@__DEV__` LESS variable for usage as a CSS guard.
-* Removed legacy custom browser targetting format and now following `browserslist` standard for desclaring supporting browsers.
+* Removed legacy custom browser targeting format and now following `browserslist` standard for declaring supporting browsers.
 
 ### lint
 
@@ -142,7 +142,7 @@ Updated all dependencies to latest releases and added support for TypeScript. In
 
 * Replaced Karma/PhantomJS/Mocha/DirtyChai testing stack with a Jest-based alternative implementation.
   * Supports Jest options like `--watch` and `--coverage` as a result.
-* Removed custom Enzyme webpack plugin since we can pre-setup Enyme directly for Jest usage.
+* Removed custom Enzyme webpack plugin since we can pre-setup Enzyme directly for Jest usage.
 * Removed Sinon in favour of Jest built-in mocking/spy functionality.
 
 ### transpile
@@ -181,11 +181,11 @@ Updated all dependencies to latest releases and added support for TypeScript. In
 
 ### pack
 
-* Added new option `--verbose` which outputs detailed build information as the process ocurrs, for specific information on what modules are being process and when.
+* Added new option `--verbose` which outputs detailed build information as the process occurs, for specific information on what modules are being process and when.
 * Added support for dynamically injecting `REACT_APP_` prefixed environment variables into app code, when used under `process.env`.
 * Added support for `@global-import "<file>";` syntax to import CSS files in a global context.
 * Added support for boolean flag option `externalStartup` in the enact options in a project's `package.json`. When true, any prerender startup scripts will be external file assets, rather than embedded inline javascript.
-* Fixed `@babel/polyfill` failing to be transpiled into targetted `core-js` components. Additionally now ensures polyfills aren't loaded more than once.
+* Fixed `@babel/polyfill` failing to be transpiled into targeted `core-js` components. Additionally now ensures polyfills aren't loaded more than once.
 * Fixed v8 snapshot support for React 16.4.1.
 * Relocated the old `./config/proptype-checker.js` into its own standalone [`mocha-react-proptype-checker`](https://www.npmjs.com/package/mocha-react-proptype-checker) package.
 * Production mode limits the UglifyJS options to ECMA 5 optimizations only.
@@ -197,7 +197,7 @@ Updated all dependencies to latest releases and added support for TypeScript. In
 
 ### template
 
-* Relocated default moonstone app template into a separate standalone [@enact/template-moonstone](https://www.npmjs.com/package/@enact/template-moonstone) package depdendency.
+* Relocated default moonstone app template into a separate standalone [@enact/template-moonstone](https://www.npmjs.com/package/@enact/template-moonstone) package dependency.
 
 ### eject
 
@@ -266,13 +266,13 @@ Enact CLI source code now updated for [`eslint-plugin-import`](https://github.co
 
 ### transpile
 
-* Added support for `-i`/`--ignore` regex string to ignore filepathes when transpiling/copying.
+* Added support for `-i`/`--ignore` regex string to ignore filepaths when transpiling/copying.
 
 ### pack
 
 * Added support for targeted builds. Can be set via a `target` enact `package.json` property or via [Browserslist](https://github.com/ai/browserslist) format.
 * Added support for Electron build target.
-* Switched to use `@babel/preset-env` and `@babel/polyfill` for on-demand transpiling/polyfilling to targetted build platforms.
+* Switched to use `@babel/preset-env` and `@babel/polyfill` for on-demand transpiling/polyfilling to targeted build platforms.
 * Production mode build uses `uglifyjs-webpack-plugin` to support ES6-based minification (until the upgrade to webpack 4)
 * Dynamic handling of the `enact` options with `package.json`, with support for `theme` preset values that simplify setup of for given Enact GUI theme libraries.
 * Allow `electron-renderer` webpack target to support `browser` as a main field.
@@ -350,13 +350,13 @@ Locked down dependencies to avoid potential regressions in patch updates to depe
 	* Array of screen literal values (empty array fo no screen types to pass)
 	* String filepath to a local project json file
 	* String path to a dependency module json file
-	* Undefined/falsey to fallback to default Moonstone
+	* Undefined/falsy to fallback to default Moonstone
 * Added support for `deep` option within the `enact` object in the `package.json`. It represents 1 or more javascript conditions that, when met, indicate the page load was originating from an external deep link, and the prerender should not be shown (as the initial state of the window will not be the prerendered content). This can be a string or a string array.
 
 ## 0.9.0 (August 21, 2017)
 
-Dependencies updated to latestly release, including support for Webpack 3.x.
-Codebased updated for ES6 syntax and the minimum version is NodeJS is now 6.4.0.
+Dependencies updated to latest release, including support for Webpack 3.x.
+Codebase updated for ES6 syntax and the minimum version is NodeJS is now 6.4.0.
 
 ### create
 
@@ -372,7 +372,7 @@ Codebased updated for ES6 syntax and the minimum version is NodeJS is now 6.4.0.
 * Output error messages after build and have watcher mode disable bailing to ensure webpack doesn't exit during watching.
 * Properly bail on error and properly avoid bailing on `--watch` flag.
 * Disable module traces when errors occur.
-* Show any warnings sucessful `pack` executions (not just when there are errors).
+* Show any warnings successful `pack` executions (not just when there are errors).
 * Uses the `react-dev-utils` eslint formatter for displaying eslint warnings and errors.
 * Limited `autoprefixer` flexbox prefixing to final and IE versions of flexbox implementation.
 * Added support for `postcss-flexbugs-fixes` to automatically fix known platform-specific flexbox issues with workarounds.
@@ -452,7 +452,7 @@ Added support for a link command (`enact link`) as a shorthand to link in Enact 
 * Added support for appinfo.json sysAssetsBasePath and $-prefix in webos-meta-webpack-plugin.
 * Will now warn about performance when building in development mode.
 * HTML template will now be used in all situations and can be customized as desired.
-* Vastly rewritten isomorphic app prerendering support with improved reliability and mmemory management.
+* Vastly rewritten isomorphic app prerendering support with improved reliability and memory management.
 * Depreciated prerendering of isomorphic apps within the HTML template has been removed. Please ensure all app entrypoints are able to self-render. See [this example](https://github.com/enactjs/cli/blob/master/template/src/index.js).
 
 ### test
@@ -475,7 +475,7 @@ All enact-dev dependencies have been updated to latest applicable revisions. If 
 
 * Transitioned from the iLib-loader to a new iLibPlugin with enhanced support for compilation-unique caching in Enact 1.0.0-beta.3. This is *not* backward compatible; please update to Enact 1.0.0-beta.3 or use an earlier release of enact-dev.
 * Supports code splitting/lazy-loading via ES6 `import()` syntax (limited to static string values).
-* WebOSMetaPlugin updated to support dynamicalling adding `usePrerendering:true` to appinfo.json files as needed.
+* WebOSMetaPlugin updated to support dynamically adding `usePrerendering:true` to appinfo.json files as needed.
 
 ### test
 
@@ -524,7 +524,7 @@ Several additional documentation files have been added to the `docs` directory, 
 
 ### pack
 
-* Added primary support for singluar entrypoints for both regular and isomorphic code layouts.
+* Added primary support for singular entrypoints for both regular and isomorphic code layouts.
 * Refactored build customization features (like `--isomorphic` and `--stats`) into separate files and cleaned up the implementations.
 * Depreciated isomorphic HTML-side rendering. Isomorphic entrypoints should render to the DOM when in a browser environment.
 
@@ -582,7 +582,7 @@ Several additional documentation files have been added to the `docs` directory, 
 
 ## 0.2.0 (October 21, 2016)
 
-* Refactored entire project into a dedicated standalone global CLI with features/functionality integrated from 
+* Refactored entire project into a dedicated standalone global CLI with features/functionality integrated from
 [create-react-app](https://github.com/facebookincubator/create-react-app)
 
 ### init
@@ -594,13 +594,13 @@ Several additional documentation files have been added to the `docs` directory, 
 * Template updated for Enact 1.0.0-alpha.2
 * The package.json and appinfo.json will update their respective `name`/`id` to the project directory's name.
 * Added `--verbose` flag option to provide detailed logging.
-* Added `--link` flag option to link any dependencies that have been `npm link` rathen than install.
+* Added `--link` flag option to link any dependencies that have been `npm link` rather than install.
 * Added `--local` flag option to include enact-dev as a local devDependency (not recommended for general usage).
-* Rennovated user interface with basic NPM script usage information included.
+* Renovated user interface with basic NPM script usage information included.
 
 ### pack
 
-* Switched from using `babel-polyfill` to a more simplified set of polyfills covering Promise, Object.assign, 
+* Switched from using `babel-polyfill` to a more simplified set of polyfills covering Promise, Object.assign,
   String.prototype.codePointAt, String.fromCodePoint, Math.sign, and Fetch APIs
 * Scans files with ESLint as part of the build process, failing on errors.
 * Switched from OS-level to a local ./node_modules/.cache/ location for babel caching in development mode.
@@ -608,16 +608,16 @@ Several additional documentation files have been added to the `docs` directory, 
 * Supports development-only CSS class `.__DEV__` which will exist withing development builds but be removed in production
   builds.
 * Includes CaseSensitivePathsPlugin to ensure paths meet case-sensitive requirements regardless of system.
-* Converted webos-meta-loader into a standalone plugin that will autodetect the appinfo.json and ensure its webOS meta assets get
-  copied over during buildtime. Additionally, if an appinfo.json is found, the `title` value will be inserted into the output
+* Converted webos-meta-loader into a standalone plugin that will auto-detect the appinfo.json and ensure its webOS meta assets get
+  copied over during build time. Additionally, if an appinfo.json is found, the `title` value will be inserted into the output
   HTML `<title></title>`.
 * PrerenderPlugin now handles Node-based Fetch API to allow isomorphic fetch operations (via @enact/fetch).
-* PrerenderPlugin will output a stack strace on failure and allow continue the build without prerendering.
+* PrerenderPlugin will output a stack trace on failure and allow continue the build without prerendering.
 * Isomorphic build format is no longer its own mode, but is now a `-i`/`--isomorphic` flag option, which will apply isomorphic layout
   to whatever the active build mode is (development or production). When the flag is present, the `isomorphic` package.json enact property
   will be used as the entrypoint.
 * The `prerender` enact property within package.json has been renamed `isomorphic` for clarity (backward compatible)
-* Simplified console output, detailing output files, filesizes, and changes in size from previous build.
+* Simplified console output, detailing output files, file sizes, and changes in size from previous build.
 
 ### serve
 

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ The @enact/cli tool will check the project's **package.json** looking for an opt
 * `theme` _[object]_ - A simplified string name to extrapolate `fontGenerator`, `ri`, and `screenTypes` preset values from. For example, `"moonstone"`
 * `fontGenerator` _[string]_ - Filepath to a CommonJS fontGenerator module which will build locale-specific font CSS to inject into the HTML. By default, will use any preset for a specified theme or fallback to moonstone.
 * `ri` _[object]_ - Resolution independence options to be forwarded to the [LESS plugin](https://github.com/enyojs/less-plugin-resolution-independence). By default, will use any preset for a specified theme or fallback to moonstone
-* `screenTypes` _[array|string]_ - Array of 1 or more screentype definitions to be used with prerender HTML initialization. Can alternatively reference a json filepath to read for screentype definitons.  By default, will use any preset for a specified theme or fallback to moonstone.
+* `screenTypes` _[array|string]_ - Array of 1 or more screentype definitions to be used with prerender HTML initialization. Can alternatively reference a json filepath to read for screentype definitions.  By default, will use any preset for a specified theme or fallback to moonstone.
 * `nodeBuiltins` _[object]_ - Configuration settings for polyfilling NodeJS built-ins. See `node` [webpack option](https://webpack.js.org/configuration/node/).
 * `externalStartup` _[boolean]_ - Flag whether to externalize the startup/update js that is normally inlined within prerendered app HTML output.
 * `forceCSSModules` _[boolean]_ - Flag whether to force all LESS/CSS to be processed in a modular context (not just the `*.module.css` and `*.module.less` files).
 * `deep` _[string|array]_ - 1 or more JavaScript conditions that, when met, indicate deeplinking and any prerender should be discarded.
-* `target` _[string|array]_ - A build-type generic preset string (see `target` [webpack option](https://webpack.js.org/configuration/target/)) or alternatively a specific [browserlist array](https://github.com/ai/browserslist) of desired targets.
+* `target` _[string|array]_ - A build-type generic preset string (see `target` [webpack option](https://webpack.js.org/configuration/target/)) or alternatively a specific [browserslist array](https://github.com/ai/browserslist) of desired targets.
 * `proxy` _[string]_ - Proxy target during project `serve` to be used within the [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware).
 
 For example:
@@ -86,7 +86,7 @@ For example:
 		}
 	}
 	...
-} 
+}
 ```
 
 

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -30,6 +30,24 @@ Run within an Enact project's source code, the `enact pack` command (aliased as 
 ## Production Mode
 By default, projects will build in development mode. When you're code is ready for deployment you can build in production mode. Production mode will minify the source code and remove dead code, along with numerous other minor code optimization strategies.
 
+## Browser Support & Polyfills
+The Enact CLI is designed to be compatible with a wide array of browsers and devices. [Browserslist standard](https://github.com/browserslist/browserslist) is used to handle targetting, with Enact's defaults being:
+
+* >1%
+* last 2 versions
+* last 5 Chrome versions
+* last 5 Firefox versions
+* Firefox ESR
+* not ie < 12
+* not ie_mob < 12
+* not dead
+
+For all projects built with Enact CLI, `core-js` polyfill is automatically included, so that all stable ECMAScript features are polyfilled across all target browsers. This means that only what's needed will be transpiled or polyfilled from `core-js`. The Bowserslist settings can be narrowed or widened at will via [`package.json` settings or `BROWSERSLIST` environment variable](https://github.com/browserslist/browserslist#queries). This means the newer the targetted browsers, the fewer the polyfills and less required transpiling.
+
+However keep in mind that `core-js` is solely for ECMAScript and does not polyfill any browser features. Features like this will need to be manually polyfilled in projects with app-level imports.  For example, to add web animation API, you could add the NPM dependency [`web-animations-js`](https://github.com/web-animations/web-animations-js) and import it at the top of your app's roor index.js source file.
+
+Note: Some ui libraries, like Moonstone, may have their own recommended supported browsers and may differ from the core Enact framework.
+
 ## \_\_DEV\_\_ Keyword
 In order to make development and debugging simpler, the enact cli supports a special `__DEV__` keyword in both javascript and LESS.
 

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -13,7 +13,7 @@ order: 4
                       (includes prerendering)
     -w, --watch       Rebuild on file changes
     -l, --locales     Locales for isomorphic mode; one of:
-            <commana-separated-values> Locale list
+            <comma-separated-values> Locale list
             <JSON-filepath> - Read locales from JSON file
             "none" - Disable locale-specific handling
             "used" - Detect locales used within ./resources/
@@ -31,7 +31,7 @@ Run within an Enact project's source code, the `enact pack` command (aliased as 
 By default, projects will build in development mode. When you're code is ready for deployment you can build in production mode. Production mode will minify the source code and remove dead code, along with numerous other minor code optimization strategies.
 
 ## Browser Support & Polyfills
-The Enact CLI is designed to be compatible with a wide array of browsers and devices. [Browserslist standard](https://github.com/browserslist/browserslist) is used to handle targetting, with Enact's defaults being:
+The Enact CLI is designed to be compatible with a wide array of browsers and devices. [Browserslist standard](https://github.com/browserslist/browserslist) is used to handle targeting, with Enact's defaults being:
 
 * >1%
 * last 2 versions
@@ -42,9 +42,9 @@ The Enact CLI is designed to be compatible with a wide array of browsers and dev
 * not ie_mob < 12
 * not dead
 
-For all projects built with Enact CLI, `core-js` polyfill is automatically included, so that all stable ECMAScript features are polyfilled across all target browsers. This means that only what's needed will be transpiled or polyfilled from `core-js`. The Bowserslist settings can be narrowed or widened at will via [`package.json` settings or `BROWSERSLIST` environment variable](https://github.com/browserslist/browserslist#queries). This means the newer the targetted browsers, the fewer the polyfills and less required transpiling.
+For all projects built with Enact CLI, `core-js` polyfill is automatically included, so that all stable ECMAScript features are polyfilled across all target browsers. This means that only what's needed will be transpiled or polyfilled from `core-js`. The Browserslist settings can be narrowed or widened at will via [`package.json` settings or `BROWSERSLIST` environment variable](https://github.com/browserslist/browserslist#queries). This means the newer the targeted browsers, the fewer the polyfills and less required transpiling.
 
-However keep in mind that `core-js` is solely for ECMAScript and does not polyfill any browser features. Features like this will need to be manually polyfilled in projects with app-level imports.  For example, to add web animation API, you could add the NPM dependency [`web-animations-js`](https://github.com/web-animations/web-animations-js) and import it at the top of your app's roor index.js source file.
+However keep in mind that `core-js` is solely for ECMAScript and does not polyfill any browser features. Features like this will need to be manually polyfilled in projects with app-level imports.  For example, to add web animation API, you could add the NPM dependency [`web-animations-js`](https://github.com/web-animations/web-animations-js) and import it at the top of your app's root **`index.js`** source file.
 
 Note: Some ui libraries, like Moonstone, may have their own recommended supported browsers and may differ from the core Enact framework.
 
@@ -73,7 +73,7 @@ In development mode, the LESS remains intact and used, but in production mode, t
 
 Some scenarios may require sensitive or dynamic data to be kept outside a project itself.  All environment variables that are prefixed with `REACT_APP_` will be supported for injection into the app output. For example, with `REACT_APP_MYVAR="Hello World"` environment variable, usage of `process.env.REACT_APP_MYVAR` will be replaced with `"Hello World"`.
 
-Furthermore, Enact CLI supports a heirarchical `.env` format for declaring environment variables within a file.
+Furthermore, Enact CLI supports a hierarchical `.env` format for declaring environment variables within a file.
 
 The following `.env` files will be processed, in overriding order:
 
@@ -94,7 +94,7 @@ Note: Changing any environment variables will require you to restart the develop
 
 ## TypeScript Support
 
-[TypeScript](https://www.typescriptlang.org) syntax support is an optional feature.  All TypeScript-based code will be automatically transpiled like normal JavaScript and packaged by Enact CLI with no additional user setup needed. However, this does not inlude enforced type-checking, solely the syntax transpiling.  Type-checking will occur automatically at buildtime, however the `typescript` dependency must be on the project itself.  You'll also want to install type definition packages for React, ReactDOM, and Jest.
+[TypeScript](https://www.typescriptlang.org) syntax support is an optional feature.  All TypeScript-based code will be automatically transpiled like normal JavaScript and packaged by Enact CLI with no additional user setup needed. However, this does not include enforced type-checking, solely the syntax transpiling.  Type-checking will occur automatically at build time, however the `typescript` dependency must be on the project itself.  You'll also want to install type definition packages for React, ReactDOM, and Jest.
 
 It's easiest to begin from the start with TypeScript by using the `typescript` template (`@enact/template-typescript` on NPM). To add TypeScript support to an existing project:
 
@@ -108,11 +108,10 @@ Optionally, [TSLint](https://palantir.github.io/tslint/) can be installed global
 By using the isomorphic code layout option, your project bundle will be outputted in a versatile universal code format allowing potential usage outside the browser. The Enact CLI takes advantage of this mode by additionally generating an HTML output of your project and embedding it directly with the resulting **index.html**. By default, isomorphic mode will attempt to prerender only `en-US`, however with the `--locales` option, a wade variety of locales can be specified and prerendered. More details on isomorphic support and its limitations can be found [here](./isomorphic-support.md).
 
 ## V8 Snapshot Generation
-The v8 snapshot blob creation feature is highly experimental and tempermental depending on your code. It is considered an extension of the isomorphic code layout, bringing along all the same requirements. Given the highly-specific nature of a v8 snapshot blob being tied to particular versions of Chrome/Chromium/Electron/etc., developers must provide their own copy of the `mksnapshot` binary and have its filepath set to the `V8_MKSNAPSHOT` environment variable.
+The v8 snapshot blob creation feature is highly experimental and temperamental depending on your code. It is considered an extension of the isomorphic code layout, bringing along all the same requirements. Given the highly-specific nature of a v8 snapshot blob being tied to particular versions of Chrome/Chromium/Electron/etc., developers must provide their own copy of the `mksnapshot` binary and have its filepath set to the `V8_MKSNAPSHOT` environment variable.
 
 ## Watcher Option
 Similar to the [`enact serve`](./serving-apps.md) command, the watcher will build the project and wait for any detected source code changes. When a change is detected, it will rebuild the project. The rebuild time will be significantly faster since the process can actively cache and build only what has changed.
 
 ## Stats Analysis
 The Bundle analysis file option uses the popular [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) to create a visual representation of the project build to **stats.html**, showing the full module hierarchy arranged by output size. This can be very useful in determining where bloat is coming from or finding dependencies that may have been included by mistake.
-

--- a/docs/starting-a-new-app.md
+++ b/docs/starting-a-new-app.md
@@ -27,12 +27,12 @@ The @enact/cli tool will check the project's **package.json** looking for an opt
 * `theme` _[object]_ - A simplified string name to extrapolate `fontGenerator`, `ri`, and `screenTypes` preset values from. For example, `"moonstone"`
 * `fontGenerator` _[string]_ - Filepath to a CommonJS fontGenerator module which will build locale-specific font CSS to inject into the HTML. By default, will use any preset for a specified theme or fallback to moonstone.
 * `ri` _[object]_ - Resolution independence options to be forwarded to the [LESS plugin](https://github.com/enyojs/less-plugin-resolution-independence). By default, will use any preset for a specified theme or fallback to moonstone
-* `screenTypes` _[array|string]_ - Array of 1 or more screentype definitions to be used with prerender HTML initialization. Can alternatively reference a json filepath to read for screentype definitons.  By default, will use any preset for a specified theme or fallback to moonstone.
+* `screenTypes` _[array|string]_ - Array of 1 or more screentype definitions to be used with prerender HTML initialization. Can alternatively reference a json filepath to read for screentype definitions.  By default, will use any preset for a specified theme or fallback to moonstone.
 * `nodeBuiltins` _[object]_ - Configuration settings for polyfilling NodeJS built-ins. See `node` [webpack option](https://webpack.js.org/configuration/node/).
 * `externalStartup` _[boolean]_ - Flag whether to externalize the startup/update js that is normally inlined within prerendered app HTML output.
 * `forceCSSModules` _[boolean]_ - Flag whether to force all LESS/CSS to be processed in a modular context (not just the `*.module.css` and `*.module.less` files).
 * `deep` _[string|array]_ - 1 or more JavaScript conditions that, when met, indicate deeplinking and any prerender should be discarded.
-* `target` _[string|array]_ - A build-type generic preset string (see `target` [webpack option](https://webpack.js.org/configuration/target/)) or alternatively a specific [browserlist array](https://github.com/ai/browserslist) of desired targets.
+* `target` _[string|array]_ - A build-type generic preset string (see `target` [webpack option](https://webpack.js.org/configuration/target/)) or alternatively a specific [browserslist array](https://github.com/ai/browserslist) of desired targets.
 * `proxy` _[string]_ - Proxy target during project `serve` to be used within the [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware).
 
 For example:
@@ -48,7 +48,7 @@ For example:
 		}
 	}
 	...
-} 
+}
 ```
 
 ## Available npm Tasks


### PR DESCRIPTION
Adds information on our default browser targets and our core-js polyfill usage (and how browser feature are not polyfilled , only ECMAScript stable features)

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>