### PR TITLE
PLAT-104442: Not correctly providing theme ResBundle constant for all themes

### DIFF
--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -26,7 +26,7 @@ const globals = {
 	ILIB_BASE_PATH: iLibDirs.find(f => fs.existsSync(path.join(app.context, f))) || iLibDirs[1],
 	ILIB_RESOURCES_PATH: 'resources',
 	ILIB_CACHE_ID: new Date().getTime() + '',
-	[rbConst(app.name.split('/').pop())]: 'resources'
+	[rbConst(app.name)]: 'resources'
 };
 
 for (let t = app.theme; t; t = t.theme) {

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -12,25 +12,26 @@ const fs = require('fs');
 const path = require('path');
 const {optionParser: app} = require('@enact/dev-utils');
 
+const rbConst = name =>
+	'ILIB_' +
+	path
+		.basename(name)
+		.replace(/[-_\s]/g, '_')
+		.toUpperCase() +
+	'_PATH';
+
 const iLibDirs = ['node_modules/@enact/i18n/ilib', 'node_modules/ilib', 'ilib'];
 const globals = {
 	__DEV__: true,
 	ILIB_BASE_PATH: iLibDirs.find(f => fs.existsSync(path.join(app.context, f))) || iLibDirs[1],
 	ILIB_RESOURCES_PATH: 'resources',
-	ILIB_CACHE_ID: new Date().getTime() + ''
+	ILIB_CACHE_ID: new Date().getTime() + '',
+	[rbConst(app.name.split('/').pop())]: 'resources'
 };
 
 for (let t = app.theme; t; t = t.theme) {
-	const themeEnv = path
-		.basename(t.name)
-		.replace(/[-_\s]/g, '_')
-		.toUpperCase();
-	globals[themeEnv] = path.relative(app.context, path.join(t.path, 'resources')).replace(/\\/g, '/');
-}
-
-if (app.name === '@enact/moonstone') {
-	globals.ILIB_MOONSTONE_PATH = 'resources';
-	globals.ILIB_RESOURCES_PATH = '_resources_';
+	const themeRB = path.join(t.path, 'resources');
+	globals[rbConst(t.name)] = path.relative(app.context, themeRB).replace(/\\/g, '/');
 }
 
 const ignorePatterns = [


### PR DESCRIPTION
Some old code in our Jest setup was only handling Moonstone constants correctly (setting `ILIB_MOONSTONE_PATH`).

There was a bug for themed apps where we were setting `<THEME>` global instead of `ILIB_<THEME>_PATH` like we were meant to. This fixes that.

Additionally, to provide generalized support for in-theme usage the local resource resbundle path is added as `ILIB_<NAME>_PATH` to cover in-theme testing and some edge cases.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>