### PR TITLE
PLAT-106664: Preserve unresolved symlinks path in output

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -154,6 +154,8 @@ module.exports = function(env) {
 			extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
 			// Allows us to specify paths to check for module resolving.
 			modules: [path.resolve('./node_modules'), 'node_modules'],
+			// Don't resolve symlinks to their underlying paths
+			symlinks: false,
 			// Backward compatibility for apps using new ilib references with old Enact
 			// and old apps referencing old iLib location with new Enact
 			alias: fs.existsSync(path.join(app.context, 'node_modules', '@enact', 'i18n', 'ilib'))
@@ -399,7 +401,7 @@ module.exports = function(env) {
 			// Automatically configure iLib library within @enact/i18n. Additionally,
 			// ensure the locale data files and the resource files are copied during
 			// the build to the output directory.
-			new ILibPlugin(),
+			new ILibPlugin({symlinks: false}),
 			// Automatically detect ./appinfo.json and ./webos-meta/appinfo.json files,
 			// and parses any to copy over any webOS meta assets at build time.
 			new WebOSMetaPlugin(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -924,9 +924,9 @@
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
     "@enact/dev-utils": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@enact/dev-utils/-/dev-utils-2.5.1.tgz",
-      "integrity": "sha512-1Qb0AmETUVqjYpxxnFp/jD3sc0Yhkt77nviuFpkKBzvgDJcLT0rAav64SzYecMM/eh2CmZ99pXSkDgqFnPFr9A==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@enact/dev-utils/-/dev-utils-2.7.0.tgz",
+      "integrity": "sha512-wWWtglAyFhe2+/RoWpRxmXoLieG/BhhDXZNY/XbfXnZFBteuNM28UZt8hUgg1iDC6aFEZWA1Qg1s72ryaQXmvA==",
       "requires": {
         "browserslist": "^4.1.0",
         "chalk": "^2.4.1",
@@ -12037,9 +12037,9 @@
       }
     },
     "webpack-bundle-analyzer": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.6.1.tgz",
-      "integrity": "sha512-Nfd8HDwfSx1xBwC+P8QMGvHAOITxNBSvu/J/mCJvOwv+G4VWkU7zir9SSenTtyCi0LnVtmsc7G5SZo1uV+bxRw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.7.0.tgz",
+      "integrity": "sha512-mETdjZ30a3Yf+NTB/wqTgACK7rAYQl5uxKK0WVTNmF0sM3Uv8s3R58YZMW7Rhu0Lk2Rmuhdj5dcH5Q76zCDVdA==",
       "requires": {
         "acorn": "^7.1.1",
         "acorn-walk": "^7.1.1",
@@ -12057,9 +12057,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+          "integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
         },
         "filesize": {
           "version": "3.6.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@babel/preset-env": "7.4.5",
     "@babel/preset-react": "7.0.0",
     "@babel/preset-typescript": "7.3.3",
-    "@enact/dev-utils": "2.5.1",
+    "@enact/dev-utils": "2.7.0",
     "@enact/template-moonstone": "3.0.0",
     "acorn": "^6.0.0",
     "babel-core": "7.0.0-bridge.0",


### PR DESCRIPTION
Requires https://github.com/enactjs/dev-utils/pull/57

Sets webpack's `resolve.symlinks` option to `false`, disabling path resolving for symlinks. This will preserve `node_modules/...` filepaths for modules linked in.

Once https://github.com/enactjs/dev-utils/pull/57 is merged and released, this PR will be updated for the new `@enact/dev-utils` version.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>