### PR TITLE
PLAT-107662: Support expanded proxy settings

### DIFF
--- a/commands/serve.js
+++ b/commands/serve.js
@@ -128,6 +128,11 @@ function devServerConfig(host, protocol, proxy, allowedHost, publicPath) {
 		public: allowedHost,
 		proxy,
 		before(build) {
+			// Optionally register app-side proxy middleware if it exists
+			const proxySetup = path.join(process.cwd(), 'src', 'setupProxy.js');
+			if (fs.existsSync(proxySetup)) {
+				require(proxySetup)(build);
+			}
 			// This lets us open files from the runtime error overlay.
 			build.use(errorOverlayMiddleware());
 		}


### PR DESCRIPTION
* Adds support for an optional app-side `./src/proxySetup.js` files which can hook in to the underlying webpack-dev-server for advanced proxy usage.
* This follows the `create-react-app` implementation format for optimal compatibility and future-handling.
* See https://create-react-app.dev/docs/proxying-api-requests-in-development/#configuring-the-proxy-manually for examples of usage.