### PR TITLE
Allow watching Enact libraries, but not nested children dependencies.

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -281,7 +281,7 @@ module.exports = function(env) {
 			// Reportedly, this avoids CPU overload on some systems.
 			// https://github.com/facebookincubator/create-react-app/issues/293
 			watchOptions: {
-				ignored: /node_modules/
+				ignored: /node_modules[\\/](?!@enact[\\/](?!.*node_modules))/
 			}
 		},
 		// Target app to build for a specific environment (default 'web')


### PR DESCRIPTION
Allows top level enact dependencies to be watched during `serve`.

The recent change of preserving symlink path (rather than resolving) altered `serve` to recognize linked Enact dependencies as falling under `./node_modules` tree, when in reality they resolve outside it to their linked location. This adds handling to avoid that and allow watchers to be attached to Enact dependency files.

Note: PR targetted to master for hotfix process. Once approved/merged, I'll do a 2.8.1 hotfix release and merge-back to develop.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>