### PR TITLE
PLAT-115954: Applies @babel/plugin-transform-runtime during standalone transpiling

### DIFF
--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -80,7 +80,7 @@ module.exports = function (api) {
 			require('@babel/plugin-proposal-optional-chaining').default,
 			require('@babel/plugin-proposal-nullish-coalescing-operator').default,
 
-			[
+			!es5Standalone && [
 				require('@babel/plugin-transform-runtime').default,
 				{
 					corejs: false,


### PR DESCRIPTION
*Applies `@babel/plugin-transform-runtime` only when not transpiling in standalone mode.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>