### PR TITLE
PLAT-116110: Use moonstone as default template

### DIFF
--- a/commands/create.js
+++ b/commands/create.js
@@ -18,7 +18,7 @@ const minimist = require('minimist');
 const validatePackageName = require('validate-npm-package-name');
 
 const ENACT_DEV_NPM = '@enact/cli';
-const INCLUDED = path.dirname(require.resolve('@enact/template-sandstone'));
+const INCLUDED = path.dirname(require.resolve('@enact/template-moonstone'));
 const TEMPLATE_DIR = path.join(process.env.APPDATA || os.homedir(), '.enact');
 
 const defaultGenerator = {
@@ -170,7 +170,7 @@ function resolveTemplateGenerator(template) {
 	return new Promise((resolve, reject) => {
 		let templatePath = path.join(TEMPLATE_DIR, template);
 		if (!fs.existsSync(templatePath)) {
-			if (['default', 'sandstone'].includes(template)) {
+			if (['default', 'moonstone'].includes(template)) {
 				templatePath = path.join(INCLUDED, 'template');
 			} else {
 				reject(new Error(`Template ${chalk.bold(template)} not found.`));

--- a/commands/template.js
+++ b/commands/template.js
@@ -10,7 +10,7 @@ const inquirer = require('react-dev-utils/inquirer');
 const tar = require('tar');
 
 const TEMPLATE_DIR = path.join(process.env.APPDATA || os.homedir(), '.enact');
-const INCLUDED = path.dirname(require.resolve('@enact/template-sandstone'));
+const INCLUDED = path.dirname(require.resolve('@enact/template-moonstone'));
 const DEFAULT_LINK = path.join(TEMPLATE_DIR, 'default');
 
 function displayHelp() {
@@ -58,10 +58,21 @@ function displayHelp() {
 function initTemplateArea() {
 	if (!fs.existsSync(TEMPLATE_DIR)) {
 		fs.mkdirSync(TEMPLATE_DIR);
+	} else {
+		// Remove any dead/unreadable link
+		fs.readdirSync(TEMPLATE_DIR)
+			.map(d => path.join(TEMPLATE_DIR, d))
+			.forEach(d => {
+				try {
+					fs.realpathSync(d);
+				} catch (e) {
+					fs.removeSync(d);
+				}
+			});
 	}
-	const init = doLink(path.join(INCLUDED, 'template'), 'sandstone');
-	const sandstoneLink = path.join(TEMPLATE_DIR, 'sandstone');
-	return init.then(() => !fs.existsSync(DEFAULT_LINK) && doLink(sandstoneLink, 'default'));
+	const init = doLink(path.join(INCLUDED, 'template'), 'moonstone');
+	const moonstoneLink = path.join(TEMPLATE_DIR, 'moonstone');
+	return init.then(() => !fs.existsSync(DEFAULT_LINK) && doLink(moonstoneLink, 'default'));
 }
 
 function doInstall(target, name) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1210,10 +1210,10 @@
         "webpack-sources": "^1.4.3"
       }
     },
-    "@enact/template-sandstone": {
-      "version": "1.0.0-pre.1",
-      "resolved": "https://registry.npmjs.org/@enact/template-sandstone/-/template-sandstone-1.0.0-pre.1.tgz",
-      "integrity": "sha512-0LKH23M/dujJEoRFH/tgmr/UJqJN7wIovsbTtdPBe3Uwn17RIwNfQ4zeKUd7FQSTlx5i7qEry/jlw5ceQ943Ng=="
+    "@enact/template-moonstone": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@enact/template-moonstone/-/template-moonstone-3.1.0.tgz",
+      "integrity": "sha512-96vjjaqP0+HL7hLL1v/WNfb+hbrp88w3EKLl8K1SFUyve1AM/+hR1lsbG1gm0VkcmNt3dq8/hqG6Su/WTTk3FA=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@babel/preset-typescript": "7.10.4",
     "@babel/runtime": "7.10.5",
     "@enact/dev-utils": "3.1.0",
-    "@enact/template-sandstone": "1.0.0-pre.1",
+    "@enact/template-moonstone": "3.1.0",
     "@pmmmwh/react-refresh-webpack-plugin": "0.3.3",
     "@typescript-eslint/eslint-plugin": "3.6.0",
     "@typescript-eslint/parser": "3.6.0",


### PR DESCRIPTION
* Switches back to moonstone template for default.
* Detection and handling of dead/unreadable links in template userspace.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>