### PR TITLE
PLAT-117141: Migrate shrinkwrap override support into CLI

### DIFF
--- a/commands/bootstrap.js
+++ b/commands/bootstrap.js
@@ -94,16 +94,17 @@ function api({
 						local
 							.filter(dep => obj.dependencies && obj.dependencies[dep])
 							.forEach(dep => {
+								const tgz = path.join(override, dep, 'package.tgz');
 								if (lockfile) {
 									obj.lockfileVersion = obj.lockfileVersion || 1;
 									obj.requires = true;
-									obj.dependencies[dep].version = `file:${path.join(override, dep, 'package.tgz')}`;
+									obj.dependencies[dep].version = 'file:' + tgz;
 									// Remove unneeded properties to avoid issues
 									['resolved', 'from', 'integrity', 'requires'].forEach(
 										key => delete obj.dependencies[dep][key]
 									);
 								} else {
-									obj.dependencies[dep] = `file:${path.join(override, dep, 'package.tgz')}`;
+									obj.dependencies[dep] = 'file:' + tgz;
 								}
 							});
 						// Backup existing and write the newly modified file

--- a/commands/bootstrap.js
+++ b/commands/bootstrap.js
@@ -94,17 +94,17 @@ function api({
 						local
 							.filter(dep => obj.dependencies && obj.dependencies[dep])
 							.forEach(dep => {
-								const tgz = path.join(override, dep, 'package.tgz');
+								const fileDep = 'file:' + path.join(override, dep, 'package.tgz');
 								if (lockfile) {
 									obj.lockfileVersion = obj.lockfileVersion || 1;
 									obj.requires = true;
-									obj.dependencies[dep].version = 'file:' + tgz;
+									obj.dependencies[dep].version = fileDep;
 									// Remove unneeded properties to avoid issues
 									['resolved', 'from', 'integrity', 'requires'].forEach(
 										key => delete obj.dependencies[dep][key]
 									);
 								} else {
-									obj.dependencies[dep] = 'file:' + tgz;
+									obj.dependencies[dep] = fileDep;
 								}
 							});
 						// Backup existing and write the newly modified file


### PR DESCRIPTION
* Migrates the package lockfile override support from https://github.com/enactjs/enact-dev-dist/blob/master/node_binaries/enact-override.js into the existing `bootstrap` command as a private/undocumented feature for internal usage.

Enact-DCO-1.0-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>