### PR TITLE
PLAT-121346: Fix 'eject --bare` doesn't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## unrelease
+## [unreleased]
 
 ### eject
 
-* fix 'eject --bare' doesn't work issue via checking '/scripts' folder exists or not
+* fixed `--bare` option to work.
 
 ## 3.0.4 (August 10, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## [unreleased]
-
-### serve
-
-* Fixed https serve is not working.
-
 ## 3.0.4 (August 10, 2020)
 
 ### create

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [unreleased]
+
+### serve
+
+* Fixed https serve is not working.
+
 ## 3.0.4 (August 10, 2020)
 
 ### create

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unrelease
+
+### eject
+
+* fix 'eject --bare' doesn't work issue via checking '/scripts' folder exists or not
+
 ## 3.0.4 (August 10, 2020)
 
 ### create

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### eject
 
-* fixed `--bare` option to work.
+* Fixed `--bare` option to work.
 
 ## 3.0.4 (August 10, 2020)
 

--- a/commands/eject.js
+++ b/commands/eject.js
@@ -159,7 +159,7 @@ function configurePackage(bare) {
 	const own = require('../package.json');
 	const app = require(path.resolve('package.json'));
 	const backup = JSON.stringify(app, null, 2) + os.EOL;
-	const availScripts = fs.readdirSync('./scripts').map(f => f.replace(/\.js$/, ''));
+	const availScripts = fs.existsSync('./scripts') ? fs.readdirSync('./scripts').map(f => f.replace(/\.js$/, '')) : [];
 	const enactCLI = new RegExp('enact (' + availScripts.join('|') + ')', 'g');
 	const eslintConfig = {extends: 'enact'};
 	const eslintIgnore = ['build/*', 'config/*', 'dist/*', 'node_modules/*', 'scripts/*'];

--- a/commands/serve.js
+++ b/commands/serve.js
@@ -99,7 +99,7 @@ function hotDevServer(config, fastRefresh) {
 function devServerConfig(host, protocol, publicPath, proxy, allowedHost) {
 	let https = false;
 	const {SSL_CRT_FILE, SSL_KEY_FILE} = process.env;
-	if (protocol === 'https' && [SSL_CRT_FILE, SSL_KEY_FILE].every(f => f && fs.existsSync(f))) {
+	if (protocol === 'https' && [SSL_CRT_FILE, SSL_KEY_FILE].all(f => f && fs.existsSync(f))) {
 		https = {
 			cert: fs.readFileSync(SSL_CRT_FILE),
 			key: fs.readFileSync(SSL_KEY_FILE)

--- a/commands/serve.js
+++ b/commands/serve.js
@@ -99,7 +99,7 @@ function hotDevServer(config, fastRefresh) {
 function devServerConfig(host, protocol, publicPath, proxy, allowedHost) {
 	let https = false;
 	const {SSL_CRT_FILE, SSL_KEY_FILE} = process.env;
-	if (protocol === 'https' && [SSL_CRT_FILE, SSL_KEY_FILE].all(f => f && fs.existsSync(f))) {
+	if (protocol === 'https' && [SSL_CRT_FILE, SSL_KEY_FILE].every(f => f && fs.existsSync(f))) {
 		https = {
 			cert: fs.readFileSync(SSL_CRT_FILE),
 			key: fs.readFileSync(SSL_KEY_FILE)


### PR DESCRIPTION
- fix 'eject --bare' doesn't work issue via checking '/scripts' folder exists or not

Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)