### PR TITLE
PLAT-120112: Fixed https serve is not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [unreleased]
+
+### serve
+
+* Fixed https serve is not working.
+
 ## 3.0.4 (August 10, 2020)
 
 ### create

--- a/commands/serve.js
+++ b/commands/serve.js
@@ -99,7 +99,7 @@ function hotDevServer(config, fastRefresh) {
 function devServerConfig(host, protocol, publicPath, proxy, allowedHost) {
 	let https = false;
 	const {SSL_CRT_FILE, SSL_KEY_FILE} = process.env;
-	if (protocol === 'https' && [SSL_CRT_FILE, SSL_KEY_FILE].all(f => f && fs.existsSync(f))) {
+	if (protocol === 'https' && [SSL_CRT_FILE, SSL_KEY_FILE].every(f => f && fs.existsSync(f))) {
 		https = {
 			cert: fs.readFileSync(SSL_CRT_FILE),
 			key: fs.readFileSync(SSL_KEY_FILE)


### PR DESCRIPTION
To resolve https://github.com/enactjs/cli/issues/228, changed `all` to `every` in `devServerConfig` function.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)