### PR TITLE
PLAT-131686: Build error founded in jenkins ui-test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [unreleased]
 
+### pack
+
+* Added `shebang-loader` for removing the hashbag
+
 ### serve
 
 * Fixed https serve is not working.

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -243,17 +243,24 @@ module.exports = function (env) {
 						{
 							test: /\.(js|mjs|jsx|ts|tsx)$/,
 							exclude: /node_modules.(?!@enact)/,
-							loader: require.resolve('babel-loader'),
-							options: {
-								configFile: path.join(__dirname, 'babel.config.js'),
-								babelrc: false,
-								// This is a feature of `babel-loader` for webpack (not Babel itself).
-								// It enables caching results in ./node_modules/.cache/babel-loader/
-								// directory for faster rebuilds.
-								cacheDirectory: !isEnvProduction,
-								cacheCompression: false,
-								compact: isEnvProduction
-							}
+							use: [
+								{
+									loader: require.resolve('babel-loader'),
+									options: {
+										configFile: path.join(__dirname, 'babel.config.js'),
+										babelrc: false,
+										// This is a feature of `babel-loader` for webpack (not Babel itself).
+										// It enables caching results in ./node_modules/.cache/babel-loader/
+										// directory for faster rebuilds.
+										cacheDirectory: !isEnvProduction,
+										cacheCompression: false,
+										compact: isEnvProduction
+									}
+								},
+								{
+									loader: 'shebang-loader'
+								}
+							]
 						},
 						// Style-based rules support both LESS and CSS format, with *.module.* extension format
 						// to designate CSS modular support.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11963,6 +11963,12 @@
         "shebang-regex": "^1.0.0"
       }
     },
+    "shebang-loader": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/shebang-loader/-/shebang-loader-0.0.1.tgz",
+      "integrity": "sha1-pAAEldRMzu++xjQ157FphWn6Uuw=",
+      "dev": true
+    },
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-prettier": "^3.1.4",
-    "prettier": "^2.0.5"
+    "prettier": "^2.0.5",
+    "shebang-loader": "0.0.1"
   }
 }


### PR DESCRIPTION
### Issue Resolved / Feature Added
Build error founded in jenkins ui-test, we have "Module parse failed: Unexpected character '#' (1:0)" error.

### Resolution
Added `shebang-loader` for removing the hashbag

### Additional Considerations
### Links
PLAT-131686

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)