### PR TITLE
PLAT-121645: Add support for new JSX Transform

### DIFF
--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -47,7 +47,7 @@ module.exports = function (api) {
 					development: env !== 'production' && !es5Standalone,
 					// Will use the native built-in instead of trying to polyfill
 					// behavior for any plugins that require one.
-					useBuiltIns: true
+					...(process.env.DISABLE_NEW_JSX_TRANSFORM ? { useBuiltIns: true } : { runtime: 'automatic' }),
 				}
 			],
 			['@babel/preset-typescript']

--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -6,6 +6,20 @@
  */
 const path = require('path');
 
+// Check if JSX transform is able
+const hasJsxRuntime = (() => {
+	if (process.env.DISABLE_NEW_JSX_TRANSFORM === 'true') {
+		return false;
+	}
+
+	try {
+		require.resolve('react/jsx-runtime');
+		return true;
+	} catch (e) {
+		return false;
+	}
+})();
+
 module.exports = function (api) {
 	const env = process.env.BABEL_ENV || process.env.NODE_ENV;
 	const es5Standalone = process.env.ES5 && process.env.ES5 !== 'false';
@@ -47,7 +61,7 @@ module.exports = function (api) {
 					development: env !== 'production' && !es5Standalone,
 					// Will use the native built-in instead of trying to polyfill
 					// behavior for any plugins that require one.
-					...(process.env.DISABLE_NEW_JSX_TRANSFORM ? {useBuiltIns: true} : {runtime: 'automatic'})
+					...(!hasJsxRuntime ? {useBuiltIns: true} : {runtime: 'automatic'})
 				}
 			],
 			['@babel/preset-typescript']

--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -47,7 +47,7 @@ module.exports = function (api) {
 					development: env !== 'production' && !es5Standalone,
 					// Will use the native built-in instead of trying to polyfill
 					// behavior for any plugins that require one.
-					...(process.env.DISABLE_NEW_JSX_TRANSFORM ? { useBuiltIns: true } : { runtime: 'automatic' }),
+					...(process.env.DISABLE_NEW_JSX_TRANSFORM ? {useBuiltIns: true} : {runtime: 'automatic'}),
 				}
 			],
 			['@babel/preset-typescript']

--- a/config/babel.config.js
+++ b/config/babel.config.js
@@ -47,7 +47,7 @@ module.exports = function (api) {
 					development: env !== 'production' && !es5Standalone,
 					// Will use the native built-in instead of trying to polyfill
 					// behavior for any plugins that require one.
-					...(process.env.DISABLE_NEW_JSX_TRANSFORM ? {useBuiltIns: true} : {runtime: 'automatic'}),
+					...(process.env.DISABLE_NEW_JSX_TRANSFORM ? {useBuiltIns: true} : {runtime: 'automatic'})
 				}
 			],
 			['@babel/preset-typescript']

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -47,6 +47,20 @@ module.exports = function (env) {
 	// Sets the browserslist default fallback set of browsers to the Enact default browser support list.
 	app.setEnactTargetsAsDefault();
 
+	// Check if JSX transform is able
+	const hasJsxRuntime = (() => {
+		if (process.env.DISABLE_NEW_JSX_TRANSFORM === 'true') {
+			return false;
+		}
+
+		try {
+			require.resolve('react/jsx-runtime');
+			return true;
+		} catch (e) {
+			return false;
+		}
+	})();
+
 	// Check if TypeScript is setup
 	const useTypeScript = fs.existsSync('tsconfig.json');
 
@@ -465,7 +479,7 @@ module.exports = function (env) {
 				baseConfig: {
 					extends: [require.resolve('eslint-config-enact')],
 					rules: {
-						...(process.env.DISABLE_NEW_JSX_TRANSFORM && {
+						...(!hasJsxRuntime && {
 							'react/jsx-uses-react': 'warn',
 							'react/react-in-jsx-scope': 'warn'
 						})

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -463,7 +463,13 @@ module.exports = function (env) {
 				resolvePluginsRelativeTo: __dirname,
 				// @remove-on-eject-begin
 				baseConfig: {
-					extends: [require.resolve('eslint-config-enact')]
+					extends: [require.resolve('eslint-config-enact')],
+					rules: {
+						...(process.env.DISABLE_NEW_JSX_TRANSFORM && {
+							'react/jsx-uses-react': 'warn',
+							'react/react-in-jsx-scope': 'warn'
+						})
+					}
 				},
 				useEslintrc: false,
 				// @remove-on-eject-end


### PR DESCRIPTION
This PR adds support for the new JSX transform.
We could turn the feature off by setting `DISABLE_NEW_JSX_TRANSFORM` to `true` via `.env` file for `enact pack`.
We can't turn the rule off for `enact lint` though.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)