### PR TITLE
PLAT-141863: Skip resolving url() of absolute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### pack
 
-* Updated webpack config to not support css/less files when absolute paths is found, to avoid build fails.
+* Changed `css-loader` options to not resolving url() of the absolute path to avoid build failures.
 
 ## 4.0.1 (April 23, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unreleased
+
+### pack
+
+* Updated webpack config to not support css/less files when absolute paths is found, to avoid build fails.
+
 ## 4.0.1 (April 23, 2021)
 
 ### test

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -97,7 +97,17 @@ module.exports = function (env) {
 				options: Object.assign(
 					{importLoaders: preProcessor ? 2 : 1, sourceMap: shouldUseSourceMap},
 					cssLoaderOptions,
-					cssLoaderOptions.modules && {modules: {getLocalIdent}}
+					cssLoaderOptions.modules && {modules: {getLocalIdent}},
+					{
+						url: url => {
+							// Don't handle absolute path urls
+							if (url[0] === '/') {
+								return false;
+							}
+
+							return true;
+						}
+					}
 				)
 			},
 			{

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -101,7 +101,7 @@ module.exports = function (env) {
 					{
 						url: url => {
 							// Don't handle absolute path urls
-							if (url[0] === '/') {
+							if (url.startsWith('/')) {
 								return false;
 							}
 


### PR DESCRIPTION
For some TV apps, they had to use absolute path in the file system in url().
css-loader 3.x version did not handle the absolute path but it's now resolving(css-loader version 4.0.0 and above).
So, webpack throws a build error regarding not founding image path which is the absolute path of the file system.
To avoid the build failure, we disabled the resolving the absolute path of url().

Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)