### PR TITLE
PLAT-141821: Fixed not reading mocks that already restored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unreleased
+
+### test
+
+* Fixed `./config/jest/setupTests.js` not reading mocks that already restored.
+
 ## 4.0.2 (May 3, 2021)
 
 ### pack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### test
 
-* Fixed `./config/jest/setupTests.js` not reading mocks that already restored.
+* Fixed `jest.restoreAllMocks()` throws errors.
 
 ## 4.0.2 (May 3, 2021)
 

--- a/config/jest/setupTests.js
+++ b/config/jest/setupTests.js
@@ -35,8 +35,14 @@ afterEach(() => {
 		.concat(console.error.mock ? console.error.mock.calls : [])
 		.filter(([m]) => filterExp.test(m));
 	const expected = 0;
-	if (console.warn.mock) console.warn.mockRestore();
-	if (console.error.mock) console.error.mockRestore();
+		
+	if (console.warn.mock) {
+		console.warn.mockRestore();
+	}
+	if (console.error.mock) {
+		console.error.mockRestore();
+	}
+
 	expect(actual).toHaveLength(expected);
 });
 

--- a/config/jest/setupTests.js
+++ b/config/jest/setupTests.js
@@ -31,7 +31,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	const actual = console.warn.mock.calls.concat(console.error.mock.calls).filter(([m]) => filterExp.test(m));
+	const actual =
+		console.warn.mock && console.error.mock
+			? console.warn.mock.calls.concat(console.error.mock.calls).filter(([m]) => filterExp.test(m))
+			: 0;
 	const expected = 0;
 	console.warn.mockRestore();
 	console.error.mockRestore();

--- a/config/jest/setupTests.js
+++ b/config/jest/setupTests.js
@@ -31,14 +31,13 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	const actual =
-		console.warn.mock && console.error.mock
-			? console.warn.mock.calls.concat(console.error.mock.calls).filter(([m]) => filterExp.test(m))
-			: 0;
-	const expected = 0;
-	console.warn.mockRestore();
-	console.error.mockRestore();
-	expect(actual).toHaveLength(expected);
+	if (console.warn.mock && console.error.mock) {
+		const actual = console.warn.mock.calls.concat(console.error.mock.calls).filter(([m]) => filterExp.test(m));
+		const expected = 0;
+		console.warn.mockRestore();
+		console.error.mockRestore();
+		expect(actual).toHaveLength(expected);
+	}
 });
 
 // Configure Enzyme to use React16 adapter.

--- a/config/jest/setupTests.js
+++ b/config/jest/setupTests.js
@@ -31,16 +31,12 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	let actual = '';
+	const actual = (console.warn.mock ? console.warn.mock.calls : [])
+		.concat(console.error.mock ? console.error.mock.calls : [])
+		.filter(([m]) => filterExp.test(m));
 	const expected = 0;
-	if (console.warn.mock) {
-		actual += console.warn.mock.calls.filter(([m]) => filterExp.test(m));
-		console.warn.mockRestore();
-	}
-	if (console.error.mock) {
-		actual += console.error.mock.calls.filter(([m]) => filterExp.test(m));
-		console.error.mockRestore();
-	}
+	if (console.warn.mock) console.warn.mockRestore();
+	if (console.error.mock) console.error.mockRestore();
 	expect(actual).toHaveLength(expected);
 });
 

--- a/config/jest/setupTests.js
+++ b/config/jest/setupTests.js
@@ -35,7 +35,7 @@ afterEach(() => {
 		.concat(console.error.mock ? console.error.mock.calls : [])
 		.filter(([m]) => filterExp.test(m));
 	const expected = 0;
-		
+
 	if (console.warn.mock) {
 		console.warn.mockRestore();
 	}

--- a/config/jest/setupTests.js
+++ b/config/jest/setupTests.js
@@ -31,13 +31,17 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	if (console.warn.mock && console.error.mock) {
-		const actual = console.warn.mock.calls.concat(console.error.mock.calls).filter(([m]) => filterExp.test(m));
-		const expected = 0;
+	let actual = '';
+	const expected = 0;
+	if (console.warn.mock) {
+		actual += console.warn.mock.calls.filter(([m]) => filterExp.test(m));
 		console.warn.mockRestore();
-		console.error.mockRestore();
-		expect(actual).toHaveLength(expected);
 	}
+	if (console.error.mock) {
+		actual += console.error.mock.calls.filter(([m]) => filterExp.test(m));
+		console.error.mockRestore();
+	}
+	expect(actual).toHaveLength(expected);
 });
 
 // Configure Enzyme to use React16 adapter.


### PR DESCRIPTION
### Issue Resolved / Feature Added
Fixed not reading mocks that already restored

### Resolution
* add undefined mock checking statements in `./config/jest/setupTests.js`

### Additional Considerations
### Links
PLAT-141821

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)