### PR TITLE
WRN-8051: Added `sanitize.css` module for supporting `postcss-normalize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## unreleased
 
-* Added `sanitize.css` module for supporting `postcss-normalize`.
+* Added `sanitize.css` dependency.
 
 ## 4.1.1 (August 27, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## unreleased
+
+* Added `sanitize.css` module for supporting `postcss-normalize`.
+
 ## 4.1.1 (August 27, 2021)
 
 * No significant changes.

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "react-test-renderer": "17.0.1",
     "resolution-independence": "1.0.0",
     "resolve": "1.17.0",
+    "sanitize.css": "^12.0.1",
     "semver": "7.3.2",
     "strip-ansi": "6.0.0",
     "style-loader": "1.2.1",


### PR DESCRIPTION
### Issue Resolved / Feature Added
Some errors found while `enact pack`

> Error: Cannot find module ‘sanitize.css/page.css’
Require stack:
/usr/local/lib/node_modules/@enact/cli/node_modules/postcss-normalize/dist/index.cjs.js
./node_modules/@enact/ui/Scroller/UiScroller.module.css
Error: Cannot find module ‘sanitize.css/page.css’
Require stack:
/usr/local/lib/node_modules/@enact/cli/node_modules/postcss-normalize/dist/index.cjs.js
./node_modules/@enact/ui/Scroller/Scroller.module.css
Error: Cannot find module ‘sanitize.css/page.css’
Require stack:
/usr/local/lib/node_modules/@enact/cli/node_modules/postcss-normalize/dist/index.cjs.js
./node_modules/@enact/sandstone/Dropdown/Dropdown.module.css

### Resolution
Added `sanitize.css` module for supporting `postcss-normalize`

### Additional Considerations
### Links
WRN-8051

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)