### PR TITLE
webpack.config.js: add webpackExtraResolvePaths

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -219,7 +219,7 @@ module.exports = function (env) {
 				ext => useTypeScript || !ext.includes('ts')
 			),
 			// Allows us to specify paths to check for module resolving.
-			modules: [path.resolve('./node_modules'), 'node_modules'],
+			modules: [path.resolve('./node_modules'), 'node_modules', ...app.webpackExtraResolvePaths],
 			// Don't resolve symlinks to their underlying paths
 			symlinks: false,
 			// Backward compatibility for apps using new ilib references with old Enact


### PR DESCRIPTION
This comes from option-parser to allow the user to supply additional paths
to the resolve.modules section, allowing for users to specify their source
or other paths, and use them with paths relative to the source root instead
of '../../..' etc

Enact-DCO-1.0-Signed-off-by: Eric Blade <blade.eric@gmail.com>