### PR TITLE
WRN-14724: Add `additionalModulePaths` to specify additional paths to search when resolving modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unreleased
+
+### pack
+
+* Added `app.additionalModulePaths` to specify paths to check for module resolving.
+
 ## 4.1.6 (December 2, 2021)
 
 ### pack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### pack
 
-* Added `app.additionalModulePaths` to specify paths to check for module resolving.
+* Added `additionalModulePaths` to enact options to specify paths to check when resolving modules.
 
 ## 4.1.6 (December 2, 2021)
 

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -162,6 +162,11 @@ module.exports = function (env) {
 			}
 		});
 
+	const getAdditionalModulePaths = (paths) => {
+		if (!paths) return [];
+		return Array.isArray(paths) ? paths : [paths];
+	};
+
 	return {
 		mode: isEnvProduction ? 'production' : 'development',
 		// Don't attempt to continue if there are any errors.
@@ -219,7 +224,11 @@ module.exports = function (env) {
 				ext => useTypeScript || !ext.includes('ts')
 			),
 			// Allows us to specify paths to check for module resolving.
-			modules: [path.resolve('./node_modules'), 'node_modules'],
+			modules: [
+				path.resolve('./node_modules'),
+				'node_modules',
+				...getAdditionalModulePaths(app.additionalModulePaths)
+			],
 			// Don't resolve symlinks to their underlying paths
 			symlinks: false,
 			// Backward compatibility for apps using new ilib references with old Enact

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -162,7 +162,7 @@ module.exports = function (env) {
 			}
 		});
 
-	const getAdditionalModulePaths = (paths) => {
+	const getAdditionalModulePaths = paths => {
 		if (!paths) return [];
 		return Array.isArray(paths) ? paths : [paths];
 	};


### PR DESCRIPTION
### Issue Resolved / Feature Added
From developers(Gitter), they want to use
`import SomeComponent from 'some-directory/component'`

rather than
`import SomeComponent from '../../../../../../../../../../some-directory/component'`
(https://webpack.kr/configuration/resolve/)

CRA also supports https://create-react-app.dev/docs/importing-a-component/#absolute-imports.

### Resolution
Add `additionalModulePaths` in enact option.
This will be used in webpack config to allow the user to supply additional paths to the resolve.modules section.

### Additional Considerations

### Links
WRN-14724

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)