### PR TITLE
WRN-19252: Fix enact pack --verbose is not working

### DIFF
--- a/commands/pack.js
+++ b/commands/pack.js
@@ -19,7 +19,7 @@ const minimist = require('minimist');
 const formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');
 const printBuildError = require('react-dev-utils/printBuildError');
 const stripAnsi = require('strip-ansi');
-const webpack = require('webpack');
+const {ProgressPlugin, webpack} = require('webpack');
 const {optionParser: app, mixins, configHelper: helper} = require('@enact/dev-utils');
 
 function displayHelp() {
@@ -257,6 +257,8 @@ function api(opts = {}) {
 
 	// Set any output path override
 	if (opts.output) config.output.path = path.resolve(opts.output);
+
+	if (opts.verbose) opts.ProgressPlugin = ProgressPlugin;
 
 	mixins.apply(config, opts);
 


### PR DESCRIPTION
In this PR, we'd like to fix enact pack --verbose is not working.
webpack's ProgressPlugin is changed to check if `compiler` is an instance of `Compiler`.
Currently, dev-utils and cli have different webpack modules so ProgressPlugin created from dev-utils cannot work correctly.
To remedy this, I've changed to create PrgressPlugin from cli's webpack module.

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)