### PR TITLE
WRO-3110: Fix `enact pack` fails on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### pack
 
-* Fixed `html-webpack-plugin` emitting unnecessary file issue.
+* Fixed `enact pack` fails on windows by excluding unnecessary file emitting from `html-webpack-plugin`.
 
 ## 5.0.0-alpha.3 (April 22, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unreleased
+
+### pack
+
+* Fixed `html-webpack-plugin` emitting unnecessary file issue.
+
 ## 5.0.0-alpha.3 (April 22, 2022)
 
 ### lint

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -354,7 +354,7 @@ module.exports = function (env, ilibAdditionalResourcesPath) {
 							// by webpacks internal loaders.
 							// Exclude `ejs` HTML templating language as that's handled by
 							// the HtmlWebpackPlugin.
-							exclude: [/\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.ejs$/, /\.json$/],
+							exclude: [/^$/, /\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.ejs$/, /\.json$/],
 							type: 'asset/resource'
 						}
 						// ** STOP ** Are you adding a new loader?


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`enact pack` fail on window 10
I'm seeing a file named `javascript,__webpack_public_path__ = __webpack_base_uri__ = htmlWebpackPluginPublicPath;` in `dist/` directory.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix html-webpack-plugin asset module support output

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-3110

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong ([taeyoung.hong@lge.com](mailto:taeyoung.hong@lge.com))