### PR TITLE
WRO-3254: Fix `enact test` can't find test files on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Fixed `enact pack` fails on windows by excluding unnecessary file emitting from `html-webpack-plugin`.
 
+### test
+
+* Fixed `enact test` fails on windows by modifying glob patterns.
+
 ## 5.0.0-alpha.3 (April 22, 2022)
 
 ### lint

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -66,9 +66,10 @@ module.exports = {
 	setupFiles: [require.resolve('../polyfills')],
 	setupFilesAfterEnv: [require.resolve('./setupTests'), userSetupFile].filter(Boolean),
 	testMatch: [
-		'<rootDir>/**/__tests__/**/*.{js,jsx,ts,tsx}',
+		'<rootDir>/**/__tests__/**/*.[jt]s?(x)',
 		'<rootDir>/**/?(*.)+(spec|test).[jt]s?(x)',
-		'<rootDir>/**/*-specs.{js,jsx,ts,tsx}'
+		'<rootDir>/**/?(*.)+(spec|test).[jt]s?(x)',
+		'<rootDir>/**/*-specs.[jt]s?(x)'
 	],
 	testPathIgnorePatterns: ignorePatterns,
 	testEnvironment: 'jsdom',

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -66,9 +66,9 @@ module.exports = {
 	setupFiles: [require.resolve('../polyfills')],
 	setupFilesAfterEnv: [require.resolve('./setupTests'), userSetupFile].filter(Boolean),
 	testMatch: [
-		'<rootDir>/**/__tests__/**/*.[jt]s?(x)',
-		'<rootDir>/**/*.+(spec|test).[jt]s?(x)',
-		'<rootDir>/**/*-specs.[jt]s?(x)'
+		'<rootDir>/**/__tests__/**/*.{js,jsx,ts,tsx}',
+		'<rootDir>/**/*.+(spec|test).{js,jsx,ts,tsx}',
+		'<rootDir>/**/*-specs.{js,jsx,ts,tsx}'
 	],
 	testPathIgnorePatterns: ignorePatterns,
 	testEnvironment: 'jsdom',

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -67,7 +67,7 @@ module.exports = {
 	setupFilesAfterEnv: [require.resolve('./setupTests'), userSetupFile].filter(Boolean),
 	testMatch: [
 		'<rootDir>/**/__tests__/**/*.[jt]s?(x)',
-		'<rootDir>/**/?(*.)+(spec|test).[jt]s?(x)',
+		'<rootDir>/**/*.+(spec|test).[jt]s?(x)',
 		'<rootDir>/**/(spec|test).[jt]s?(x)',
 		'<rootDir>/**/*-specs.[jt]s?(x)'
 	],

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -68,7 +68,6 @@ module.exports = {
 	testMatch: [
 		'<rootDir>/**/__tests__/**/*.[jt]s?(x)',
 		'<rootDir>/**/*.+(spec|test).[jt]s?(x)',
-		'<rootDir>/**/(spec|test).[jt]s?(x)',
 		'<rootDir>/**/*-specs.[jt]s?(x)'
 	],
 	testPathIgnorePatterns: ignorePatterns,

--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -68,7 +68,7 @@ module.exports = {
 	testMatch: [
 		'<rootDir>/**/__tests__/**/*.[jt]s?(x)',
 		'<rootDir>/**/?(*.)+(spec|test).[jt]s?(x)',
-		'<rootDir>/**/?(*.)+(spec|test).[jt]s?(x)',
+		'<rootDir>/**/(spec|test).[jt]s?(x)',
 		'<rootDir>/**/*-specs.[jt]s?(x)'
 	],
 	testPathIgnorePatterns: ignorePatterns,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`npm run test` is not working on windows environment

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
fix testMatch that supports windows os

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-3254

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong ([taeyoung.hong@lge.com](mailto:taeyoung.hong@lge.com))