### PR TITLE
WRO-6720: Fix stats filter to show snapshot_blob.bin log

### DIFF
--- a/commands/pack.js
+++ b/commands/pack.js
@@ -147,8 +147,8 @@ function copyPublicFolder(output) {
 // Print a detailed summary of build files.
 function printFileSizes(stats, output) {
 	const assets = stats
-		.toJson({all: false, assets: true})
-		.assets.filter(asset => /\.(js|css|bin)$/.test(asset.name))
+		.toJson({assets: true})
+		.assets.filter(asset => /^(?!.*chunk).*\.(js|css|bin)$/.test(asset.name))
 		.map(asset => {
 			const size = fs.statSync(path.join(output, asset.name)).size;
 			return {


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When we `enact pack --snapshot`, the below log is showing(without logging snapshot_blob.bin).

> Compiled successfully.
NOTICE: This build contains debugging functionality and may run slower than in production mode.
        3.14 MB         dist/main.js
        228.17 kB       dist/main.css

(snapshot_blob.bin log is not shown but it was constructed)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fix stats filter to show snapshot_blob.bin log

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Remove chunk files log that too annoy and not necessary.

### Links
[//]: # (Related issues, references)
WRO-6720

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)