### PR TITLE
WRO-521: Update documentation for troubleshooting `cannot find module` error of globally installed module

### DIFF
--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -102,6 +102,13 @@ It's easiest to begin from the start with TypeScript by using the `typescript` t
 npm install --save typescript @types/react @types/react-dom @types/jest
 ```
 
+Note: If you receive an error when building the app that says `Cannot find module 'typescript'`, try to set `NODE_PATH` to point global
+node_modules directory like below.
+
+```bash
+export NODE_PATH=/path/to/your/global/node_modules
+```
+
 Optionally, [ESLint](https://eslint.org) can be installed globally or locally and configured within a project to enable linting support within the `enact lint` command.
 
 ## Sass Support

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -102,13 +102,6 @@ It's easiest to begin from the start with TypeScript by using the `typescript` t
 npm install --save typescript @types/react @types/react-dom @types/jest
 ```
 
-Note: If you receive an error when building the app that says `Cannot find module 'typescript'`, try to set `NODE_PATH` to point global
-node_modules directory like below.
-
-```bash
-export NODE_PATH=/path/to/your/global/node_modules
-```
-
 Optionally, [ESLint](https://eslint.org) can be installed globally or locally and configured within a project to enable linting support within the `enact lint` command.
 
 ## Sass Support
@@ -120,13 +113,6 @@ To use Sass, install Sass globally:
 
 ```bash
 npm install -g sass
-```
-
-Note: If you receive an error when building the app that says `Cannot find module 'sass'`, try to set `NODE_PATH` to point global
-node_modules directory like below.
-
-```bash
-export NODE_PATH=/path/to/your/global/node_modules
 ```
 
 Now you can rename `src/App.css` to `src/App.scss` or `src/App.sass` and for using CSS modules, `src/App.module.scss` or `src/App.module.sass`. And update `src/App.js` to import `src/App.scss`. Enact CLI will compile these files properly through webpack for you.
@@ -143,8 +129,6 @@ To use Tailwindcss, install Tailwindcss globally:
 ```bash
 npm install -g tailwindcss
 ```
-
-Note: If you receive an error when building the app that says `Cannot find module 'tailwindcss'`, try to set `NODE_PATH` to point global node_modules directory.
 
 And then run the init command to generate tailwind.config.js in your app:
 
@@ -203,6 +187,14 @@ const MainPanel = kind({
 ```
 
 More information can be found [here](https://tailwindcss.com/docs) to learn about tailwindcss.
+
+### Troubleshoot: Cannot find module
+Note: If you receive an error when building the app that says `Cannot find module` after installing the module globally,
+try to set `NODE_PATH` to point global node_modules directory like below.
+
+```bash
+export NODE_PATH=/path/to/your/global/node_modules
+```
 
 ## Isomorphic Support & Prerendering
 By using the isomorphic code layout option, your project bundle will be outputted in a versatile universal code format allowing potential usage outside the browser. The Enact CLI takes advantage of this mode by additionally generating an HTML output of your project and embedding it directly with the resulting **index.html**. By default, isomorphic mode will attempt to prerender only `en-US`, however with the `--locales` option, a wide variety of locales can be specified and prerendered. More details on isomorphic support and its limitations can be found [here](./isomorphic-support.md).

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -188,8 +188,8 @@ const MainPanel = kind({
 
 More information can be found [here](https://tailwindcss.com/docs) to learn about tailwindcss.
 
-### Troubleshoot: Cannot find module
-Note: If you receive an error when building the app that says `Cannot find module` after installing the module globally,
+### Troubleshooting
+If you receive an error when building the app that says `Cannot find module: 'typescript/sass/tailwindcss'` after installing the modules above(e.g. `typescript`, `sass`, or `tailwindcss`) globally,
 try to set `NODE_PATH` to point global node_modules directory like below.
 
 ```bash


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Enact CLI supports serve, pack, lint, and test for TypeScript apps with an optional way by installing the 'typescript' module globally.
Currently, even we do this, we have an error that says below.
> Failed to compile
.
[eslint] Failed to load plugin '@typescript-eslint' declared in 'BaseConfig » /home/taeyoung.hong/webos_build_server/WRO-521/cli/node_modules/eslint-config-enact/index.js#overrides[0]': Cannot find module 'typescript'

In this case, we can try to set `NODE_PATH` to point global, then the compile success.
> Creating a development build...
Compiled successfully.
NOTICE: This build contains debugging functionality and may run slower than in production mode.
.
        3.15 MB         dist/main.js
        218.48 kB       dist/main.css

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update documentation for troubleshooting `cannot find module` error of globally installed modules.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)

### Links
[//]: # (Related issues, references)
WRO-521

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong ([taeyoung.hong@lge.com](mailto:taeyoung.hong@lge.com))