### PR TITLE
WRO-8722: Update in-editor linting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ npm install -g eslint
 Then, you will need to uninstall any previous globally-installed Enact linting package (everything but eslint itself):
 
 ```sh
-npm remove -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel @babel/eslint-parser eslint-plugin-jest eslint-plugin-enact eslint-config-enact
+npm uninstall -g eslint-plugin-react eslint-plugin-react-hooks eslint-plugin-babel @babel/eslint-parser eslint-plugin-jest eslint-plugin-enact eslint-config-enact
 ```
 
 ## Copyright and License Information

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ For example:
 }
 ```
 
-
 ## Displaying Lint Output in the Editor
 
 Some editors, including Sublime Text, Atom, and Visual Studio Code, provide plugins for ESLint.
@@ -104,6 +103,21 @@ You would need to install an ESLint plugin for your editor first.
 Ever since ESLint 6, global installs of ESLint configs are no longer supported.
 To work around this new limitation, while still supporting in-editor linting, we've created a new [eslint-config-enact-proxy](https://github.com/enactjs/eslint-config-enact-proxy) package.
 The [eslint-config-enact-proxy](https://github.com/enactjs/eslint-config-enact-proxy) acts like a small proxy config, redirecting ESLint to use a globally-installed Enact ESLint config.
+In order for in-editor linting, `eslint-config-enact-proxy` should be installed locally on a project:
+
+```sh
+npm install --save-dev eslint-config-enact-proxy
+```
+
+And you should modify `package.json` or `.eslintrc` in the project's root, change the following lines:
+
+```json
+{
+  "extends": "enact-proxy"
+}
+```
+>**NOTE**: For strict mode, use `"extends": "enact-proxy/strict"`.
+
 In order for in-editor linting to work with our updated ESLint config, you'll need to upgrade to ESLint 7 or later. This can be installed globally by running:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -103,18 +103,18 @@ You would need to install an ESLint plugin for your editor first.
 Ever since ESLint 6, global installs of ESLint configs are no longer supported.
 To work around this new limitation, while still supporting in-editor linting, we've created a new [eslint-config-enact-proxy](https://github.com/enactjs/eslint-config-enact-proxy) package.
 The [eslint-config-enact-proxy](https://github.com/enactjs/eslint-config-enact-proxy) acts like a small proxy config, redirecting ESLint to use a globally-installed Enact ESLint config.
-In order for in-editor linting, `eslint-config-enact-proxy` should be installed locally on a project:
+`eslint-config-enact-proxy` needs to be installed locally on a project to enable in-editor linting:
 
 ```sh
 npm install --save-dev eslint-config-enact-proxy
 ```
 
-And you should modify `package.json` or `.eslintrc` in the project's root, change the following lines:
+Also, you need to modify `eslintConfig` property in `package.json`:
 
 ```json
-{
-  "extends": "enact-proxy"
-}
+  "eslintConfig": {
+    "extends": "enact-proxy"
+  },
 ```
 >**NOTE**: For strict mode, use `"extends": "enact-proxy/strict"`.
 


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Enact CLI supports in-editor linting by installing the 'eslint-config-enact-proxy' module locally.
But for ease to use, we need to guide users more kindly and in detail.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add a guide for installing eslint-config-enact-proxy

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-8722

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)