### PR TITLE
WRO-8972: Fix DeprecationWarning when `enact serve`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### serve
 
-* Updated devServerConfig to replace deprecated `onBeforeSetupMiddleware` and `onAfterSetupMiddleware` with `setupMiddlewares`.
+* Updated devServerConfig to replace deprecated API.
 
 ## 5.0.1 (August 30, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unreleased
+
+### serve
+
+* Updated devServerConfig to replace deprecated `onBeforeSetupMiddleware` and `onAfterSetupMiddleware` with `setupMiddlewares`.
+
 ## 5.0.1 (August 30, 2022)
 
 ### pack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### serve
 
-* Updated devServerConfig to replace deprecated API.
+* Fixed deprecation warning regarding middleware.
 
 ## 5.0.1 (August 30, 2022)
 

--- a/commands/serve.js
+++ b/commands/serve.js
@@ -225,7 +225,9 @@ function devServerConfig(host, port, protocol, publicPath, proxy, allowedHost) {
 				// Keep `evalSourceMapMiddleware`
 				// middlewares before `redirectServedPath` otherwise will not have any effect
 				// This lets us fetch source contents from webpack for the error overlay
-				evalSourceMapMiddleware(devServer),
+				evalSourceMapMiddleware(devServer)
+			);
+			middlewares.push(
 				// Redirect to `PUBLIC_URL` or `homepage`/`enact.publicUrl` from `package.json`
 				// if url not match
 				redirectServedPathMiddleware(publicPath)

--- a/commands/serve.js
+++ b/commands/serve.js
@@ -221,17 +221,20 @@ function devServerConfig(host, port, protocol, publicPath, proxy, allowedHost) {
 			if (fs.existsSync(proxySetup)) {
 				require(proxySetup)(devServer.app);
 			}
+
 			middlewares.unshift(
 				// Keep `evalSourceMapMiddleware`
 				// middlewares before `redirectServedPath` otherwise will not have any effect
 				// This lets us fetch source contents from webpack for the error overlay
 				evalSourceMapMiddleware(devServer)
 			);
+
 			middlewares.push(
 				// Redirect to `PUBLIC_URL` or `homepage`/`enact.publicUrl` from `package.json`
 				// if url not match
 				redirectServedPathMiddleware(publicPath)
 			);
+
 			return middlewares;
 		}
 	};

--- a/commands/serve.js
+++ b/commands/serve.js
@@ -211,22 +211,26 @@ function devServerConfig(host, port, protocol, publicPath, proxy, allowedHost) {
 		},
 		// `proxy` is run between `before` and `after` `webpack-dev-server` hooks
 		proxy,
-		onBeforeSetupMiddleware(devServer) {
-			// Keep `evalSourceMapMiddleware`
-			// middlewares before `redirectServedPath` otherwise will not have any effect
-			// This lets us fetch source contents from webpack for the error overlay
-			devServer.app.use(evalSourceMapMiddleware(devServer));
+		setupMiddlewares(middlewares, devServer) {
+			if (!devServer) {
+				throw new Error('webpack-dev-server is not defined');
+			}
 
 			// Optionally register app-side proxy middleware if it exists
 			const proxySetup = path.join(process.cwd(), 'src', 'setupProxy.js');
 			if (fs.existsSync(proxySetup)) {
 				require(proxySetup)(devServer.app);
 			}
-		},
-		onAfterSetupMiddleware(devServer) {
-			// Redirect to `PUBLIC_URL` or `homepage`/`enact.publicUrl` from `package.json`
-			// if url not match
-			devServer.app.use(redirectServedPathMiddleware(publicPath));
+			middlewares.unshift(
+				// Keep `evalSourceMapMiddleware`
+				// middlewares before `redirectServedPath` otherwise will not have any effect
+				// This lets us fetch source contents from webpack for the error overlay
+				evalSourceMapMiddleware(devServer),
+				// Redirect to `PUBLIC_URL` or `homepage`/`enact.publicUrl` from `package.json`
+				// if url not match
+				redirectServedPathMiddleware(publicPath)
+			);
+			return middlewares;
 		}
 	};
 }


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When we serve the app, the below warning is showing.
> (node:12686) [DEP_WEBPACK_DEV_SERVER_ON_AFTER_SETUP_MIDDLEWARE] DeprecationWarning: 'onAfterSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 (node:12686) [DEP_WEBPACK_DEV_SERVER_ON_BEFORE_SETUP_MIDDLEWARE] DeprecationWarning: 'onBeforeSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option.

In webpack.js.org, these 2 options are deprecated in favor of the [devServer.setupMiddlewares](https://webpack.js.org/configuration/dev-server/#devserversetupmiddlewares) option.
(Check these links: 
https://webpack.js.org/configuration/dev-server/#devserveronaftersetupmiddleware
https://webpack.js.org/configuration/dev-server/#devserveronbeforesetupmiddleware)


### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Replace deprecated `onBeforeSetupMiddleware` and `onAfterSetupMiddleware` with `setupMiddlewares`
(Migration guide: https://webpack.js.org/configuration/dev-server/#devserversetupmiddlewares)

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-8972

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)