### PR TITLE
WRO-9005: Made `--custom-skin` public and added documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unreleased
+
+### pack
+
+* Added `--custom-skin` option to build with custom skin for sandstone apps.
+
 ## 5.0.2 (September 16, 2022)
 
 * Pinned versions of dependencies as same as 5.0.0.

--- a/commands/pack.js
+++ b/commands/pack.js
@@ -46,6 +46,7 @@ function displayHelp() {
 	console.log('    -s, --snapshot    Generate V8 snapshot blob');
 	console.log('                      (requires V8_MKSNAPSHOT set)');
 	console.log('    -m, --meta        JSON to override package.json enact metadata');
+	console.log('    -c, --custom-skin Build with a custom skin');
 	console.log('    --stats           Output bundle analysis file');
 	console.log('    --verbose         Verbose log build details');
 	console.log('    -v, --version     Display version information');
@@ -59,7 +60,6 @@ function displayHelp() {
 			--externals           	Specify a local directory path to the standalone external framework
 			--externals-public    	Remote public path to the external framework for use injecting into HTML
 			--externals-polyfill  	Flag whether to use external polyfill (or include in framework build)
-			--custom-skin         	To use a custom skin for build
 			--ilib-additional-path	Specify iLib additional resources path
 	*/
 	process.exit(0);
@@ -301,6 +301,7 @@ function cli(args) {
 			l: 'locales',
 			s: 'snapshot',
 			m: 'meta',
+			c: 'custom-skin',
 			w: 'watch',
 			h: 'help'
 		}

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -199,7 +199,24 @@ export NODE_PATH=/path/to/your/global/node_modules
 
 ## Custom Skin Support
 
-Enact supports custom skin features to let you easily override the colors of components. All you need to do is build your app with `--custom-skin` option and add a JSON file named `custom_skin.css` which includes a preset of colors, under `customizations` folder in the build result.
+Enact supports custom skin features to let you easily override the colors of components. All you need to do is build your app with `--custom-skin` option and add a JSON file named `custom_skin.css` which includes a preset of colors, under `customizations` folder in the build result like below.
+
+```none
+my-app/
+  README.md
+  .gitignore
+  package.json
+  dist/
+    customizations/
+      custom_skin.css
+    main.css
+    main.js
+    ...
+  node_modules/
+  src/
+  resources/
+  webos-meta/
+```
 
 ## Isomorphic Support & Prerendering
 By using the isomorphic code layout option, your project bundle will be outputted in a versatile universal code format allowing potential usage outside the browser. The Enact CLI takes advantage of this mode by additionally generating an HTML output of your project and embedding it directly with the resulting **index.html**. By default, isomorphic mode will attempt to prerender only `en-US`, however with the `--locales` option, a wide variety of locales can be specified and prerendered. More details on isomorphic support and its limitations can be found [here](./isomorphic-support.md).

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -199,7 +199,7 @@ export NODE_PATH=/path/to/your/global/node_modules
 
 ## Custom Skin Support
 
-Enact supports custom skin features to let you easily override the colors of components. All you need to do is build your app with `--custom-skin` option and add a JSON file named `custom_skin.css` which includes a preset of colors, under the `customizations` folder in the build result like below.
+Sandstone supports custom skin features to let you easily override the colors of components. All you need to do is build your app with `--custom-skin` option and add a JSON file named `custom_skin.css` which includes a preset of colors, under the `customizations` folder in the build result like below.
 
 ```none
 my-app/

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -199,7 +199,7 @@ export NODE_PATH=/path/to/your/global/node_modules
 
 ## Custom Skin Support
 
-Enact supports custom skin features to let you easily override the colors of components. All you need to do is build your app with `--custom-skin` option and add a JSON file named `custom_skin.css` which includes a preset of colors, under `customizations` folder in the build result like below.
+Enact supports custom skin features to let you easily override the colors of components. All you need to do is build your app with `--custom-skin` option and add a JSON file named `custom_skin.css` which includes a preset of colors, under the `customizations` folder in the build result like below.
 
 ```none
 my-app/

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -22,6 +22,7 @@ order: 4
             "all" - All locales that iLib supports
     -s, --snapshot    Generate V8 snapshot blob
                       (requires V8_MKSNAPSHOT set)
+    -c, --custom-skin Build with a custom skin
     --stats           Output bundle analysis file
 
 ```
@@ -195,6 +196,10 @@ try to set `NODE_PATH` to point global node_modules directory like below.
 ```bash
 export NODE_PATH=/path/to/your/global/node_modules
 ```
+
+## Custom Skin Support
+
+Enact supports custom skin features to let you easily override the colors of components. All you need to do is build your app with `--custom-skin` option and add a JSON file named `custom_skin.css` which includes a preset of colors, under `customizations` folder in the build result.
 
 ## Isomorphic Support & Prerendering
 By using the isomorphic code layout option, your project bundle will be outputted in a versatile universal code format allowing potential usage outside the browser. The Enact CLI takes advantage of this mode by additionally generating an HTML output of your project and embedding it directly with the resulting **index.html**. By default, isomorphic mode will attempt to prerender only `en-US`, however with the `--locales` option, a wide variety of locales can be specified and prerendered. More details on isomorphic support and its limitations can be found [here](./isomorphic-support.md).


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
sandstone supports custom skin features to let user easily override the colors of components via css variables.
Templates for the app need to load `custom_skin.css` which includes  a preset of colors.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
To support this, we've added `--custom-skin` option to pack command to load `custom_skin.css` file from the template.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRO-9005

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)