### PR TITLE
WRP-9045: Update babel-preset-enact to fix isomorphic build fail on Node 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## unrelease
+## unreleased
 
 ### pack
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ### pack
 
-* Updated Babel support:
-  * Added `plugin-proposal-export-namespace-from`, `plugin-proposal-numeric-separator`, `plugin-syntax-dynamic-import`, `plugin-proposal-optional-chaining`, and `plugin-proposal-nullish-coalescing-operator`
+* Updated `babel-preset-enact` to `0.1.1` to fix isomorphic build failures on Node 12.
 
 ## 5.1.1 (February 10, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## unrelease
+
+### pack
+
+* Updated Babel support:
+  * Added `plugin-proposal-export-namespace-from`, `plugin-proposal-numeric-separator`, `plugin-syntax-dynamic-import`, `plugin-proposal-optional-chaining`, and `plugin-proposal-nullish-coalescing-operator`
+
 ## 5.1.1 (February 10, 2023)
 
 * Fixed `eslint-plugin-react` version to `7.31.11` temporarily.

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "babel-loader": "^8.2.5",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-plugin-transform-rename-import": "^2.3.0",
-    "babel-preset-enact": "^0.1.0",
+    "babel-preset-enact": "^0.1.1",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
     "chalk": "^4.1.2",
     "core-js": "3.22.8",


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
sandstone sample app qa-a11y build failed in Node 12 because optional chaining is not supported in Node 12.
We need to restore polyfills including 'optional chaining' in babel configs.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Update babel-preset-enact v0.1.1

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-9045

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)