### PR TITLE
WRP-1058: Fixed enact test `--watch` option is not working with the latest `jest-watch-typeahead`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### test
 
-* Fixed `--watch` option is not working by removing `v8-compile-cache` module.
+* Fixed `--watch` option is not working with the latest `jest-watch-typeahead` module.
 
 ## 5.1.2 (February 21, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## unreleased
 
 * Upgraded `eslint-plugin-react` version to `^7.32.2`.
-* Removed `v8-compile-cache` dependency to fix problems related to ESM modules.
+* Removed `v8-compile-cache` dependency to fix problems related to ES modules.
 
 ### test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+Removed `v8-compile-cache` dependency to fix problems related to ESM modules.
+
+### test
+
+* Updated `jest-watch-typeahead` to `2.2.2`.
+
 ## 5.1.2 (February 21, 2023)
 
 ### pack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 ## unreleased
 
 * Upgraded `eslint-plugin-react` version to `^7.32.2`.
-* Removed `v8-compile-cache` dependency to fix problems related to ES modules.
 
 ### test
 
-* Updated `jest-watch-typeahead` to `2.2.2`.
+* Fixed `--watch` option is not working by removing `v8-compile-cache` module.
 
 ## 5.1.2 (February 21, 2023)
 

--- a/bin/enact.js
+++ b/bin/enact.js
@@ -2,8 +2,6 @@
 
 'use strict';
 
-require('v8-compile-cache');
-
 const chalk = require('chalk');
 const semver = require('semver');
 const pkg = require('../package.json');

--- a/commands/eject.js
+++ b/commands/eject.js
@@ -32,7 +32,6 @@ const internal = [
 	'less-plugin-npm-import',
 	'semver',
 	'tar',
-	'v8-compile-cache',
 	'validate-npm-package-name'
 ];
 const enhanced = ['chalk', 'cross-spawn', 'filesize', 'fs-extra', 'minimist', 'strip-ansi'];

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "html-webpack-plugin": "^5.5.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.5.1",
-    "jest-watch-typeahead": "2.2.2",
+    "jest-watch-typeahead": "^2.2.2",
     "less": "^4.1.3",
     "less-loader": "^8.1.1",
     "less-plugin-npm-import": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "html-webpack-plugin": "^5.5.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.5.1",
-    "jest-watch-typeahead": "0.6.5",
+    "jest-watch-typeahead": "2.2.2",
     "less": "^4.1.3",
     "less-loader": "^8.1.1",
     "less-plugin-npm-import": "^2.1.0",
@@ -115,7 +115,6 @@
     "style-loader": "^3.3.1",
     "tar": "^6.1.13",
     "terser-webpack-plugin": "^5.3.6",
-    "v8-compile-cache": "^2.3.0",
     "validate-npm-package-name": "^3.0.0",
     "webpack": "^5.75.0",
     "webpack-dev-server": "^4.11.1"


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`enact test --watch` option is not working with the latest `jest-watch-typeahead`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Removed `v8-compile-cache` dependency that did not work with ES modules and updated `jest-watch-typeahead` to its latest version.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Version 2.0.0 or later of `jest-watch-typeahead` dropped support for node 12 and 17. (https://github.com/jest-community/jest-watch-typeahead/blob/main/CHANGELOG.md)
When this PR is merged, node 14+ will be needed.

### Links
[//]: # (Related issues, references)
WRP-1058

### Comments
