### PR TITLE
WRP-11042: Add a private build option to turn off effects like animation

### DIFF
--- a/commands/pack.js
+++ b/commands/pack.js
@@ -54,13 +54,14 @@ function displayHelp() {
 	console.log();
 	/*
 		Private Options:
-			--entry              	 Specify an override entrypoint
+			--entry              	Specify an override entrypoint
 			--no-minify           	Will skip minification during production build
 			--framework           	Builds the @enact/*, react, and react-dom into an external framework
 			--externals           	Specify a local directory path to the standalone external framework
 			--externals-public    	Remote public path to the external framework for use injecting into HTML
 			--externals-polyfill  	Flag whether to use external polyfill (or include in framework build)
 			--ilib-additional-path	Specify iLib additional resources path
+			--no-animation          Build without effects such as animation and shadow
 	*/
 	process.exit(0);
 }
@@ -253,6 +254,7 @@ function api(opts = {}) {
 	const config = configFactory(
 		opts.production ? 'production' : 'development',
 		opts.isomorphic,
+		!opts.animation,
 		opts['ilib-additional-path']
 	);
 
@@ -288,12 +290,13 @@ function cli(args) {
 			'production',
 			'isomorphic',
 			'snapshot',
+			'animation',
 			'verbose',
 			'watch',
 			'help'
 		],
 		string: ['externals', 'externals-public', 'locales', 'entry', 'ilib-additional-path', 'output', 'meta'],
-		default: {minify: true},
+		default: {minify: true, animation: true},
 		alias: {
 			o: 'output',
 			p: 'production',

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -41,7 +41,7 @@ const createEnvironmentHash = require('./createEnvironmentHash');
 
 // This is the production and development configuration.
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
-module.exports = function (env, isomorphic = false, ilibAdditionalResourcesPath) {
+module.exports = function (env, isomorphic = false, noAnimation = false, ilibAdditionalResourcesPath) {
 	process.chdir(app.context);
 
 	// Load applicable .env files into environment variables.
@@ -481,7 +481,10 @@ module.exports = function (env, isomorphic = false, ilibAdditionalResourcesPath)
 				'process.env.PUBLIC_URL': JSON.stringify(publicPath),
 				// Define ENACT_PACK_ISOMORPHIC global variable to determine to use
 				// `hydrateRoot` for isomorphic build and `createRoot` for non-isomorphic build by app.
-				ENACT_PACK_ISOMORPHIC: isomorphic
+				ENACT_PACK_ISOMORPHIC: isomorphic,
+				// Define ENACT_PACK_NO_ANIMATION global variable to determine
+				// whether to build including effects such as animation or shadow or not.
+				ENACT_PACK_NO_ANIMATION: noAnimation
 			}),
 			// Inject prefixed environment variables within code, when used
 			new EnvironmentPlugin(Object.keys(process.env).filter(key => /^(REACT_APP|WDS_SOCKET)/.test(key))),


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
To provide a way to turn off effects like animation from theme libraries, we need to add a build option.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a private build option `--no-animation` to turn off effects like animation or shadow.
It will define `ENACT_PACK_NO_ANIMATION` environment variable to turn the effects off conditionally from UI code.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-11042, WRP-3555

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)