### PR TITLE
WRP-10063: Removed `@testing-library/dom` dependency and upgraded `@testing-library/react` to v^14.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased
+
+* Removed `@testing-library/dom` dependency.
+* Updated `@testing-library/react` version to `^14.0.0`.
+
 ## 5.1.3 (April 11, 2023)
 
 * Updated `eslint-plugin-react` version to `^7.32.2`.

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@enact/dev-utils": "^5.1.1",
     "@enact/template-sandstone": "^1.5.2",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
-    "@testing-library/dom": "^8.20.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@enact/template-sandstone": "^1.5.2",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^13.5.0",
     "@typescript-eslint/eslint-plugin": "^5.48.2",
     "babel-jest": "^27.5.1",


### PR DESCRIPTION
Enact-DCO-1.0-Signed-off-by: Stanca Pop [stanca.pop@lgepartner.com](mailto:stanca.pop@lgepartner.com)

### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
With the Enact CLI 5.1.2 release there was a `@testing-library/dom` upgrade to version 9.0.0. This version has some breaking changes and caused unit tests to fail. `@testing-library/dom` package does not need to be explicitly set in package.json, as it comes as a peerDependency in `@testing-library/user-event`. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
We need to remove `@testing-library/dom` dependency from package.json and also upgrade `@testing-library/react` to major version ^14.0.0 (in the release noted, Features section, it mentions: "Bump @testing-library/dom to 9.0.0"). It seems the two packages are dependent on each other.    https://github.com/testing-library/react-testing-library/releases 

`@testing-library/react` ^14.0.0 BREAKING CHANGES:
- See https://github.com/testing-library/dom-testing-library/releases/tag/v9.0.0
- Minimum supported Node.js version is now 14.x

This upgrade fixed unit tests fails.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-10063

### Comments
