### PR TITLE
WRP-1058: Fixed enact test `--watch` option is not working with the newer versions of `jest-watch-typeahead`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,13 @@ module.exports = {
 		node: true
 	},
 	extends: ['enact', 'plugin:prettier/recommended', 'prettier'],
+	parserOptions: {
+		ecmaFeatures: {
+			jsx: true
+		},
+		ecmaVersion: 'latest',
+		sourceType: 'module'
+	},
 	plugins: ['import'],
 	rules: {
 		'import/no-unresolved': ['error', {commonjs: true, caseSensitive: true}],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### test
 
-* Fixed `--watch` option is not working by removing `v8-compile-cache` module.
+* Fixed `--watch` option is not working with the latest `jest-watch-typeahead` module.
 
 ## 5.1.2 (February 21, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 ## unreleased
 
-* Upgraded `eslint-plugin-react` version to `^7.32.2`.
-
 ### test
 
 * Fixed `--watch` option is not working with the latest `jest-watch-typeahead` module.
+
+## 5.1.3 (April 11, 2023)
+
+* Updated `eslint-plugin-react` version to `^7.32.2`.
+* Updated dependencies.
 
 ## 5.1.2 (February 21, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### test
 
-* Fixed `--watch` option is not working with the latest `jest-watch-typeahead` module.
+* Fixed `--watch` option is not working with the newest `jest-watch-typeahead` modules.
 
 ## 5.1.3 (April 11, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## Unreleased
+## unreleased
 
-Removed `v8-compile-cache` dependency to fix problems related to ESM modules.
+* Upgraded `eslint-plugin-react` version to `^7.32.2`.
+* Removed `v8-compile-cache` dependency to fix problems related to ESM modules.
 
 ### test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## unreleased
 
 * Upgraded `eslint-plugin-react` version to `^7.32.2`.
-* Removed `v8-compile-cache` dependency to fix problems related to ESM modules.
+* Removed `v8-compile-cache` dependency to fix problems related to ES modules.
 
 ### test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+Removed `v8-compile-cache` dependency to fix problems related to ESM modules.
+
+### test
+
+* Updated `jest-watch-typeahead` to `2.2.2`.
+
 ## 5.1.2 (February 21, 2023)
 
 ### pack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 ## unreleased
 
 * Upgraded `eslint-plugin-react` version to `^7.32.2`.
-* Removed `v8-compile-cache` dependency to fix problems related to ES modules.
 
 ### test
 
-* Updated `jest-watch-typeahead` to `2.2.2`.
+* Fixed `--watch` option is not working by removing `v8-compile-cache` module.
 
 ## 5.1.2 (February 21, 2023)
 

--- a/bin/enact.js
+++ b/bin/enact.js
@@ -2,8 +2,6 @@
 
 'use strict';
 
-require('v8-compile-cache');
-
 const chalk = require('chalk');
 const semver = require('semver');
 const pkg = require('../package.json');

--- a/commands/eject.js
+++ b/commands/eject.js
@@ -32,7 +32,6 @@ const internal = [
 	'less-plugin-npm-import',
 	'semver',
 	'tar',
-	'v8-compile-cache',
 	'validate-npm-package-name'
 ];
 const enhanced = ['chalk', 'cross-spawn', 'filesize', 'fs-extra', 'minimist', 'strip-ansi'];

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "html-webpack-plugin": "^5.5.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.5.1",
-    "jest-watch-typeahead": "^2.2.2",
+    "jest-watch-typeahead": "^1.1.0",
     "less": "^4.1.3",
     "less-loader": "^8.1.1",
     "less-plugin-npm-import": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "html-webpack-plugin": "^5.5.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.5.1",
-    "jest-watch-typeahead": "2.2.2",
+    "jest-watch-typeahead": "^2.2.2",
     "less": "^4.1.3",
     "less-loader": "^8.1.1",
     "less-plugin-npm-import": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enact/cli",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Full-featured build environment tool for Enact applications.",
   "main": "index.js",
   "author": "Jason Robitaille <jason.robitaille@lge.com>",
@@ -45,7 +45,7 @@
   "dependencies": {
     "@babel/eslint-plugin": "^7.19.1",
     "@babel/plugin-transform-modules-commonjs": "^7.21.2",
-    "@enact/dev-utils": "^5.1.1",
+    "@enact/dev-utils": "^5.1.2",
     "@enact/template-sandstone": "^1.5.2",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
     "@testing-library/dom": "^8.20.0",
@@ -67,8 +67,8 @@
     "dotenv": "^16.0.3",
     "dotenv-expand": "^8.0.3",
     "eslint": "^8.35.0",
-    "eslint-config-enact": "^4.1.3",
-    "eslint-plugin-enact": "^1.0.1",
+    "eslint-config-enact": "^4.1.4",
+    "eslint-plugin-enact": "^1.0.2",
     "eslint-plugin-jest": "^26.6.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.32.2",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "html-webpack-plugin": "^5.5.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.5.1",
-    "jest-watch-typeahead": "0.6.5",
+    "jest-watch-typeahead": "2.2.2",
     "less": "^4.1.3",
     "less-loader": "^8.1.1",
     "less-plugin-npm-import": "^2.1.0",
@@ -115,7 +115,6 @@
     "style-loader": "^3.3.1",
     "tar": "^6.1.13",
     "terser-webpack-plugin": "^5.3.6",
-    "v8-compile-cache": "^2.3.0",
     "validate-npm-package-name": "^3.0.0",
     "webpack": "^5.75.0",
     "webpack-dev-server": "^4.11.1"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "@babel/eslint-plugin": "^7.19.1",
-    "@babel/plugin-transform-modules-commonjs": "^7.20.11",
+    "@babel/plugin-transform-modules-commonjs": "^7.21.2",
     "@enact/dev-utils": "^5.1.1",
     "@enact/template-sandstone": "^1.5.2",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
@@ -52,7 +52,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "@typescript-eslint/eslint-plugin": "^5.48.2",
+    "@typescript-eslint/eslint-plugin": "^5.54.1",
     "babel-jest": "^27.5.1",
     "babel-loader": "^8.2.5",
     "babel-plugin-dynamic-import-node": "^2.3.3",
@@ -66,14 +66,14 @@
     "css-minimizer-webpack-plugin": "^3.4.1",
     "dotenv": "^16.0.3",
     "dotenv-expand": "^8.0.3",
-    "eslint": "^8.32.0",
+    "eslint": "^8.35.0",
     "eslint-config-enact": "^4.1.3",
     "eslint-plugin-enact": "^1.0.1",
     "eslint-plugin-jest": "^26.6.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",
-    "eslint-plugin-react": "7.31.11",
+    "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-testing-library": "^5.9.1",
+    "eslint-plugin-testing-library": "^5.10.2",
     "eslint-webpack-plugin": "^3.2.0",
     "expose-loader": "^3.1.0",
     "file-loader": "^6.2.0",
@@ -89,8 +89,8 @@
     "less-loader": "^8.1.1",
     "less-plugin-npm-import": "^2.1.0",
     "license-checker": "^25.0.1",
-    "mini-css-extract-plugin": "^2.7.2",
-    "minimist": "^1.2.7",
+    "mini-css-extract-plugin": "^2.7.3",
+    "minimist": "^1.2.8",
     "node-polyfill-webpack-plugin": "^1.1.4",
     "postcss": "^8.4.21",
     "postcss-flexbugs-fixes": "^5.0.2",
@@ -114,9 +114,9 @@
     "strip-ansi": "^6.0.1",
     "style-loader": "^3.3.1",
     "tar": "^6.1.13",
-    "terser-webpack-plugin": "^5.3.6",
+    "terser-webpack-plugin": "^5.3.7",
     "validate-npm-package-name": "^3.0.0",
-    "webpack": "^5.75.0",
+    "webpack": "^5.76.0",
     "webpack-dev-server": "^4.11.1"
   },
   "optionalDependencies": {
@@ -131,9 +131,9 @@
     }
   },
   "devDependencies": {
-    "eslint-config-prettier": "^8.6.0",
+    "eslint-config-prettier": "^8.7.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^4.2.1",
-    "prettier": "^2.8.3"
+    "prettier": "^2.8.4"
   }
 }


### PR DESCRIPTION
### Checklist

* [X] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [X] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [X] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
`enact test --watch` option is not working with the latest `jest-watch-typeahead`

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Removed `v8-compile-cache` dependency that did not work with ES modules and updated `jest-watch-typeahead` to 1.1.0 version.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-1058

### Comments
