### PR TITLE
WRP-13739: Fixed `ResizeObserver loop limit exceeded` error

### DIFF
--- a/commands/serve.js
+++ b/commands/serve.js
@@ -191,7 +191,8 @@ function devServerConfig(host, port, protocol, publicPath, proxy, allowedHost) {
 			},
 			overlay: {
 				errors: true,
-				warnings: false
+				warnings: false,
+				runtimeErrors: false
 			}
 		},
 		devMiddleware: {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Starting cli 5.1.0 "webpack-dev-server" was updated to lated minor version "^4.9.3". Version 4.12.0 introduced an error that is visible on our console app in agate-apps. 
With this version of "webpack-dev-server", at first render or whenever we resize the browser viewport (e.g. by opening developer tools), an error overlay pops up stating "ResizeObserver loop limit exceeded". 
This issue is addressed on "webpack-dev-server"'s Github repo: https://github.com/webpack/webpack-dev-server/issues/4771. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The fix for this: https://github.com/webpack/webpack-dev-server/pull/4773. "webpack-dev-server" added this option to show or not runtime errors in an overlay (the default value is true). So if we add `runtimeErrors: false` in cli we do not get the `ResizeObserver loop limit exceeded` error any more. 

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-13739

### Comments
Enact-DCO-1.0-Signed-off-by: Stanca Pop stanca.pop@lgepartner.com