### PR TITLE
WRP-3673: Add a pack option `--content-hash` to support better caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## unreleased
 
+* Updated all dependencies to the latest including Jest 29 and Typescript 5.
+* Updated the minimum version of Node to `14.17.0` and dropped the support for Node 12 and 17.
+
 ### pack
 
 * Added `--content-hash` option to support app caching.
-* Updated all dependencies to the latest including Jest 29 and Typescript 5.
-* Updated the minimum version of Node to `14.17.0` and dropped the support for Node 12 and 17.
 
 ### serve
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### pack
 
-* Added `--content-hash` option to support app caching.
+* Added `--content-hash` option to add a unique hash to output file names to support better caching.
 
 ### serve
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## unreleased
 
+### pack
+
+* Added `--content-hash` option to support app caching.
+
 ### serve
 
 * Fixed to disable overlay for runtime errors.

--- a/commands/pack.js
+++ b/commands/pack.js
@@ -62,7 +62,7 @@ function displayHelp() {
 			--externals-polyfill  	Flag whether to use external polyfill (or include in framework build)
 			--ilib-additional-path	Specify iLib additional resources path
 			--no-animation          Build without effects such as animation and shadow
-			--add-contenthash       Add the hash of the chunk, including only elements of this content type
+			--content-hash       Add the hash of the chunk, including only elements of this content type
 	*/
 	process.exit(0);
 }
@@ -256,7 +256,7 @@ function api(opts = {}) {
 		opts.production ? 'production' : 'development',
 		opts.isomorphic,
 		!opts.animation,
-		opts['add-contenthash'],
+		opts['content-hash'],
 		opts['ilib-additional-path']
 	);
 
@@ -293,7 +293,7 @@ function cli(args) {
 			'isomorphic',
 			'snapshot',
 			'animation',
-			'add-contenthash',
+			'content-hash',
 			'verbose',
 			'watch',
 			'help'

--- a/commands/pack.js
+++ b/commands/pack.js
@@ -30,13 +30,13 @@ function displayHelp() {
 	console.log(`    ${e} [options]`);
 	console.log();
 	console.log('  Options');
-	console.log('    -o, --output         Specify an output directory');
-	console.log('    -ch, --content-hash  Add a unique hash to output files based on the content of an asset');
-	console.log('    -w, --watch          Rebuild on file changes');
-	console.log('    -p, --production     Build in production mode');
-	console.log('    -i, --isomorphic     Use isomorphic code layout');
-	console.log('                         (includes prerendering)');
-	console.log('    -l, --locales        Locales for isomorphic mode; one of:');
+	console.log('    -o, --output      Specify an output directory');
+	console.log('    --content-hash    Add a unique hash to output files based on the content of an asset');
+	console.log('    -w, --watch       Rebuild on file changes');
+	console.log('    -p, --production  Build in production mode');
+	console.log('    -i, --isomorphic  Use isomorphic code layout');
+	console.log('                      (includes prerendering)');
+	console.log('    -l, --locales     Locales for isomorphic mode; one of:');
 	console.log('            <commana-separated-values> Locale list');
 	console.log('            <JSON-filepath> - Read locales from JSON file');
 	console.log('            "none" - Disable locale-specific handling');
@@ -44,14 +44,14 @@ function displayHelp() {
 	console.log('            "tv" - Locales supported on webOS TV');
 	console.log('            "signage" - Locales supported on webOS signage');
 	console.log('            "all" - All locales that iLib supports');
-	console.log('    -s, --snapshot       Generate V8 snapshot blob');
-	console.log('                         (requires V8_MKSNAPSHOT set)');
-	console.log('    -m, --meta           JSON to override package.json enact metadata');
-	console.log('    -c, --custom-skin    Build with a custom skin');
-	console.log('    --stats              Output bundle analysis file');
-	console.log('    --verbose            Verbose log build details');
-	console.log('    -v, --version        Display version information');
-	console.log('    -h, --help           Display help information');
+	console.log('    -s, --snapshot    Generate V8 snapshot blob');
+	console.log('                      (requires V8_MKSNAPSHOT set)');
+	console.log('    -m, --meta        JSON to override package.json enact metadata');
+	console.log('    -c, --custom-skin Build with a custom skin');
+	console.log('    --stats           Output bundle analysis file');
+	console.log('    --verbose         Verbose log build details');
+	console.log('    -v, --version     Display version information');
+	console.log('    -h, --help        Display help information');
 	console.log();
 	/*
 		Private Options:
@@ -307,7 +307,6 @@ function cli(args) {
 			l: 'locales',
 			s: 'snapshot',
 			m: 'meta',
-			ch: 'content-hash',
 			c: 'custom-skin',
 			w: 'watch',
 			h: 'help'

--- a/commands/pack.js
+++ b/commands/pack.js
@@ -31,7 +31,7 @@ function displayHelp() {
 	console.log();
 	console.log('  Options');
 	console.log('    -o, --output      Specify an output directory');
-	console.log('    --content-hash    Add a unique hash to output files based on the content of an asset');
+	console.log('    --content-hash    Add a unique hash to output file names based on the content of an asset');
 	console.log('    -w, --watch       Rebuild on file changes');
 	console.log('    -p, --production  Build in production mode');
 	console.log('    -i, --isomorphic  Use isomorphic code layout');

--- a/commands/pack.js
+++ b/commands/pack.js
@@ -30,12 +30,13 @@ function displayHelp() {
 	console.log(`    ${e} [options]`);
 	console.log();
 	console.log('  Options');
-	console.log('    -o, --output      Specify an output directory');
-	console.log('    -w, --watch       Rebuild on file changes');
-	console.log('    -p, --production  Build in production mode');
-	console.log('    -i, --isomorphic  Use isomorphic code layout');
-	console.log('                      (includes prerendering)');
-	console.log('    -l, --locales     Locales for isomorphic mode; one of:');
+	console.log('    -o, --output         Specify an output directory');
+	console.log('    -ch, --content-hash  Add a unique hash to output files based on the content of an asset');
+	console.log('    -w, --watch          Rebuild on file changes');
+	console.log('    -p, --production     Build in production mode');
+	console.log('    -i, --isomorphic     Use isomorphic code layout');
+	console.log('                         (includes prerendering)');
+	console.log('    -l, --locales        Locales for isomorphic mode; one of:');
 	console.log('            <commana-separated-values> Locale list');
 	console.log('            <JSON-filepath> - Read locales from JSON file');
 	console.log('            "none" - Disable locale-specific handling');
@@ -43,15 +44,14 @@ function displayHelp() {
 	console.log('            "tv" - Locales supported on webOS TV');
 	console.log('            "signage" - Locales supported on webOS signage');
 	console.log('            "all" - All locales that iLib supports');
-	console.log('    -s, --snapshot    Generate V8 snapshot blob');
-	console.log('                      (requires V8_MKSNAPSHOT set)');
-	console.log('    -m, --meta        JSON to override package.json enact metadata');
-	console.log('    -c, --custom-skin Build with a custom skin');
-	console.log('    --content-hash    Add the hash of the chunk');
-	console.log('    --stats           Output bundle analysis file');
-	console.log('    --verbose         Verbose log build details');
-	console.log('    -v, --version     Display version information');
-	console.log('    -h, --help        Display help information');
+	console.log('    -s, --snapshot       Generate V8 snapshot blob');
+	console.log('                         (requires V8_MKSNAPSHOT set)');
+	console.log('    -m, --meta           JSON to override package.json enact metadata');
+	console.log('    -c, --custom-skin    Build with a custom skin');
+	console.log('    --stats              Output bundle analysis file');
+	console.log('    --verbose            Verbose log build details');
+	console.log('    -v, --version        Display version information');
+	console.log('    -h, --help           Display help information');
 	console.log();
 	/*
 		Private Options:
@@ -254,9 +254,9 @@ function api(opts = {}) {
 	const configFactory = require('../config/webpack.config');
 	const config = configFactory(
 		opts.production ? 'production' : 'development',
+		opts['content-hash'],
 		opts.isomorphic,
 		!opts.animation,
-		opts['content-hash'],
 		opts['ilib-additional-path']
 	);
 
@@ -284,6 +284,7 @@ function api(opts = {}) {
 function cli(args) {
 	const opts = minimist(args, {
 		boolean: [
+			'content-hash',
 			'custom-skin',
 			'minify',
 			'framework',
@@ -293,7 +294,6 @@ function cli(args) {
 			'isomorphic',
 			'snapshot',
 			'animation',
-			'content-hash',
 			'verbose',
 			'watch',
 			'help'
@@ -307,6 +307,7 @@ function cli(args) {
 			l: 'locales',
 			s: 'snapshot',
 			m: 'meta',
+			ch: 'content-hash',
 			c: 'custom-skin',
 			w: 'watch',
 			h: 'help'

--- a/commands/pack.js
+++ b/commands/pack.js
@@ -62,6 +62,7 @@ function displayHelp() {
 			--externals-polyfill  	Flag whether to use external polyfill (or include in framework build)
 			--ilib-additional-path	Specify iLib additional resources path
 			--no-animation          Build without effects such as animation and shadow
+			--add-contenthash       Add the hash of the chunk, including only elements of this content type
 	*/
 	process.exit(0);
 }
@@ -255,6 +256,7 @@ function api(opts = {}) {
 		opts.production ? 'production' : 'development',
 		opts.isomorphic,
 		!opts.animation,
+		opts['add-contenthash'],
 		opts['ilib-additional-path']
 	);
 
@@ -291,6 +293,7 @@ function cli(args) {
 			'isomorphic',
 			'snapshot',
 			'animation',
+			'add-contenthash',
 			'verbose',
 			'watch',
 			'help'

--- a/commands/pack.js
+++ b/commands/pack.js
@@ -47,6 +47,7 @@ function displayHelp() {
 	console.log('                      (requires V8_MKSNAPSHOT set)');
 	console.log('    -m, --meta        JSON to override package.json enact metadata');
 	console.log('    -c, --custom-skin Build with a custom skin');
+	console.log('    --content-hash    Add the hash of the chunk');
 	console.log('    --stats           Output bundle analysis file');
 	console.log('    --verbose         Verbose log build details');
 	console.log('    -v, --version     Display version information');
@@ -62,7 +63,6 @@ function displayHelp() {
 			--externals-polyfill  	Flag whether to use external polyfill (or include in framework build)
 			--ilib-additional-path	Specify iLib additional resources path
 			--no-animation          Build without effects such as animation and shadow
-			--content-hash       Add the hash of the chunk, including only elements of this content type
 	*/
 	process.exit(0);
 }

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -214,7 +214,7 @@ module.exports = function (
 			// Generated JS file names (with nested folders).
 			// There will be one main bundle, and one file per asynchronous chunk.
 			// We don't currently advertise code splitting but Webpack supports it.
-			filename: '[name].js',
+			filename: contenthash ? '[name].[contenthash].js' : '[name].js',
 			// There are also additional JS chunk files if you use code splitting.
 			chunkFilename: contenthash ? 'chunk.[name].[contenthash].js' : 'chunk.[name].js',
 			assetModuleFilename: '[path][name][ext]',
@@ -497,7 +497,7 @@ module.exports = function (
 			// Note: this won't work without MiniCssExtractPlugin.loader in `loaders`.
 			!process.env.INLINE_STYLES &&
 				new MiniCssExtractPlugin({
-					filename: '[name].css',
+					filename: contenthash ? '[name].[contenthash].css' : '[name].css',
 					chunkFilename: contenthash ? 'chunk.[name].[contenthash].css' : 'chunk.[name].css'
 				}),
 			// Webpack5 removed node polyfills but we need this to run screenshot tests

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -41,7 +41,7 @@ const createEnvironmentHash = require('./createEnvironmentHash');
 
 // This is the production and development configuration.
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
-module.exports = function (env, isomorphic = false, noAnimation = false, ilibAdditionalResourcesPath) {
+module.exports = function (env, isomorphic = false, noAnimation = false, contenthash = false, ilibAdditionalResourcesPath) {
 	process.chdir(app.context);
 
 	// Load applicable .env files into environment variables.
@@ -208,9 +208,9 @@ module.exports = function (env, isomorphic = false, noAnimation = false, ilibAdd
 			// Generated JS file names (with nested folders).
 			// There will be one main bundle, and one file per asynchronous chunk.
 			// We don't currently advertise code splitting but Webpack supports it.
-			filename: '[name].[contenthash].js',
+			filename: '[name].js',
 			// There are also additional JS chunk files if you use code splitting.
-			chunkFilename: 'chunk.[name].[contenthash].js',
+			chunkFilename: contenthash ? 'chunk.[name].[contenthash].js' : 'chunk.[name].js',
 			assetModuleFilename: '[path][name][ext]',
 			// Add /* filename */ comments to generated require()s in the output.
 			pathinfo: !isEnvProduction,
@@ -492,7 +492,7 @@ module.exports = function (env, isomorphic = false, noAnimation = false, ilibAdd
 			!process.env.INLINE_STYLES &&
 				new MiniCssExtractPlugin({
 					filename: '[name].css',
-					chunkFilename: 'chunk.[name].css'
+					chunkFilename: contenthash ? 'chunk.[name].[contenthash].css' : 'chunk.[name].css'
 				}),
 			// Webpack5 removed node polyfills but we need this to run screenshot tests
 			new NodePolyfillPlugin(),

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -208,9 +208,9 @@ module.exports = function (env, isomorphic = false, noAnimation = false, ilibAdd
 			// Generated JS file names (with nested folders).
 			// There will be one main bundle, and one file per asynchronous chunk.
 			// We don't currently advertise code splitting but Webpack supports it.
-			filename: '[name].js',
+			filename: '[name].[contenthash].js',
 			// There are also additional JS chunk files if you use code splitting.
-			chunkFilename: 'chunk.[name].js',
+			chunkFilename: 'chunk.[name].[contenthash].js',
 			assetModuleFilename: '[path][name][ext]',
 			// Add /* filename */ comments to generated require()s in the output.
 			pathinfo: !isEnvProduction,

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -43,9 +43,9 @@ const createEnvironmentHash = require('./createEnvironmentHash');
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
 module.exports = function (
 	env,
+	contentHash = false,
 	isomorphic = false,
 	noAnimation = false,
-	contenthash = false,
 	ilibAdditionalResourcesPath
 ) {
 	process.chdir(app.context);
@@ -214,10 +214,10 @@ module.exports = function (
 			// Generated JS file names (with nested folders).
 			// There will be one main bundle, and one file per asynchronous chunk.
 			// We don't currently advertise code splitting but Webpack supports it.
-			filename: contenthash ? '[name].[contenthash].js' : '[name].js',
+			filename: contentHash ? '[name].[contenthash].js' : '[name].js',
 			// There are also additional JS chunk files if you use code splitting.
-			chunkFilename: contenthash ? 'chunk.[name].[contenthash].js' : 'chunk.[name].js',
-			assetModuleFilename: contenthash ? '[path][name][contenthash][ext]' : '[path][name][ext]',
+			chunkFilename: contentHash ? 'chunk.[name].[contenthash].js' : 'chunk.[name].js',
+			assetModuleFilename: contentHash ? '[path][name][contenthash][ext]' : '[path][name][ext]',
 			// Add /* filename */ comments to generated require()s in the output.
 			pathinfo: !isEnvProduction,
 			publicPath,
@@ -497,8 +497,8 @@ module.exports = function (
 			// Note: this won't work without MiniCssExtractPlugin.loader in `loaders`.
 			!process.env.INLINE_STYLES &&
 				new MiniCssExtractPlugin({
-					filename: contenthash ? '[name].[contenthash].css' : '[name].css',
-					chunkFilename: contenthash ? 'chunk.[name].[contenthash].css' : 'chunk.[name].css'
+					filename: contentHash ? '[name].[contenthash].css' : '[name].css',
+					chunkFilename: contentHash ? 'chunk.[name].[contenthash].css' : 'chunk.[name].css'
 				}),
 			// Webpack5 removed node polyfills but we need this to run screenshot tests
 			new NodePolyfillPlugin(),

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -217,7 +217,7 @@ module.exports = function (
 			filename: contenthash ? '[name].[contenthash].js' : '[name].js',
 			// There are also additional JS chunk files if you use code splitting.
 			chunkFilename: contenthash ? 'chunk.[name].[contenthash].js' : 'chunk.[name].js',
-			assetModuleFilename: '[path][name][ext]',
+			assetModuleFilename: contenthash ? '[path][name][contenthash][ext]' : '[path][name][ext]',
 			// Add /* filename */ comments to generated require()s in the output.
 			pathinfo: !isEnvProduction,
 			publicPath,

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -41,7 +41,13 @@ const createEnvironmentHash = require('./createEnvironmentHash');
 
 // This is the production and development configuration.
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
-module.exports = function (env, isomorphic = false, noAnimation = false, contenthash = false, ilibAdditionalResourcesPath) {
+module.exports = function (
+	env,
+	isomorphic = false,
+	noAnimation = false,
+	contenthash = false,
+	ilibAdditionalResourcesPath
+) {
 	process.chdir(app.context);
 
 	// Load applicable .env files into environment variables.

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -8,11 +8,11 @@ order: 4
     enact pack [options]
 
   Options
-    -p, --production  Build in production mode
-    -i, --isomorphic  Use isomorphic code layout
-                      (includes prerendering)
-    -w, --watch       Rebuild on file changes
-    -l, --locales     Locales for isomorphic mode; one of:
+    -p, --production     Build in production mode
+    -i, --isomorphic     Use isomorphic code layout
+                         (includes prerendering)
+    -w, --watch          Rebuild on file changes
+    -l, --locales        Locales for isomorphic mode; one of:
             <comma-separated-values> Locale list
             <JSON-filepath> - Read locales from JSON file
             "none" - Disable locale-specific handling
@@ -20,11 +20,11 @@ order: 4
             "tv" - Locales supported on webOS TV
             "signage" - Locales supported on webOS signage
             "all" - All locales that iLib supports
-    -s, --snapshot    Generate V8 snapshot blob
-                      (requires V8_MKSNAPSHOT set)
-    -c, --custom-skin Build with a custom skin
-    --content-hash    Add the hash of the chunk
-    --stats           Output bundle analysis file
+    -s, --snapshot       Generate V8 snapshot blob
+                         (requires V8_MKSNAPSHOT set)
+    -c, --custom-skin    Build with a custom skin
+    -ch, --content-hash  Add the hash of the chunk
+    --stats              Output bundle analysis file
 
 ```
 Run within an Enact project's source code, the `enact pack` command (aliased as `npm run pack` or `npm run pack-p` for production) will process and bundle the js, css, and asset files into the `./dist` directory. An **index.html** file will be dynamically generated.
@@ -219,9 +219,9 @@ my-app/
   webos-meta/
 ```
 
-## [contenthash] Injection
+## Caching Support
 
-For supporting [`Caching`](https://webpack.kr/guides/caching), Enact CLI supports adding the hash of the chunk. You can use the [`contenthash`](https://webpack.js.org/configuration/output/#template-strings) substitutions setting to define the names of your output files.
+For supporting [`Caching`](https://webpack.js.org/guides/caching/), Enact CLI provide `--content-hash` option to add the a unique hash called [`contenthash`](https://webpack.js.org/configuration/output/#template-strings) substitution.
 
 The `contenthash` substitution will add a unique hash based on the content of an asset.
 ```none

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -237,7 +237,6 @@ main.205199ab45963f6a62ec.js     544 kB       0  [emitted]  [big]  main
                   index.html  197 bytes          [emitted]
 ```
 
-
 ## Isomorphic Support & Prerendering
 By using the isomorphic code layout option, your project bundle will be outputted in a versatile universal code format allowing potential usage outside the browser. The Enact CLI takes advantage of this mode by additionally generating an HTML output of your project and embedding it directly with the resulting **index.html**. By default, isomorphic mode will attempt to prerender only `en-US`, however with the `--locales` option, a wide variety of locales can be specified and prerendered. More details on isomorphic support and its limitations can be found [here](./isomorphic-support.md).
 

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -219,18 +219,19 @@ my-app/
   webos-meta/
 ```
 
-## Caching Support
+## Caching
 
-For supporting [`Caching`](https://webpack.js.org/guides/caching/), Enact CLI provide `--content-hash` option to add the a unique hash called [`contenthash`](https://webpack.js.org/configuration/output/#template-strings) substitution.
+For supporting better [`Caching`](https://webpack.js.org/guides/caching/), Enact CLI provides `--content-hash` option to add a unique hash to each output file name based on the content of an asset.
 
-The `contenthash` substitution will add a unique hash based on the content of an asset.
+Building With this option should produce the following output:
+
 ```none
                        Asset       Size  Chunks                    Chunk Names
 main.7e2c49a622975ebd9b7e.js     544 kB       0  [emitted]  [big]  main
                   index.html  197 bytes          [emitted]
 ```
 
-When the asset's content changes, `contenthash` will change as well.
+When the content changes, the output file name will change as well.
 ```none
                        Asset       Size  Chunks                    Chunk Names
 main.205199ab45963f6a62ec.js     544 kB       0  [emitted]  [big]  main

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -236,7 +236,7 @@ When the content changes, the output file name will change as well.
         199.85 kB       dist/main.2088c66150ab73b27793.css
 ```
 
-> **NOTE** The filename `main.*.js` will be changed after bundling, without changes. This is because webpack includes certain boilerplate, specifically the runtime and manifest, in the entry chunk.
+> **NOTE** The filename `main.*.js` will be changed after another building, even without making any changes. This is because webpack includes certain boilerplate, specifically the runtime and manifest, in the entry chunk.
 
 ## Isomorphic Support & Prerendering
 By using the isomorphic code layout option, your project bundle will be outputted in a versatile universal code format allowing potential usage outside the browser. The Enact CLI takes advantage of this mode by additionally generating an HTML output of your project and embedding it directly with the resulting **index.html**. By default, isomorphic mode will attempt to prerender only `en-US`, however with the `--locales` option, a wide variety of locales can be specified and prerendered. More details on isomorphic support and its limitations can be found [here](./isomorphic-support.md).

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -23,6 +23,7 @@ order: 4
     -s, --snapshot    Generate V8 snapshot blob
                       (requires V8_MKSNAPSHOT set)
     -c, --custom-skin Build with a custom skin
+    --content-hash    Add the hash of the chunk
     --stats           Output bundle analysis file
 
 ```
@@ -176,7 +177,7 @@ Here is the example.
 ```js
 const MainPanel = kind({
     name: 'MainPanel',
- 
+
     render: (props) => (
         <Panel {...props}>
             <p className="text-3xl font-bold underline">
@@ -217,6 +218,25 @@ my-app/
   resources/
   webos-meta/
 ```
+
+## [contenthash] Injection
+
+For supporting [`Caching`](https://webpack.kr/guides/caching), Enact CLI supports content hash features. You can use the [`contenthash`](https://webpack.js.org/configuration/output/#template-strings) substitutions setting to define the names of your output files.
+
+The `contenthash` substitution will add a unique hash based on the content of an asset.
+```none
+                       Asset       Size  Chunks                    Chunk Names
+main.7e2c49a622975ebd9b7e.js     544 kB       0  [emitted]  [big]  main
+                  index.html  197 bytes          [emitted]
+```
+
+When the asset's content changes, `contenthash` will change as well.
+```none
+                       Asset       Size  Chunks                    Chunk Names
+main.205199ab45963f6a62ec.js     544 kB       0  [emitted]  [big]  main
+                  index.html  197 bytes          [emitted]
+```
+
 
 ## Isomorphic Support & Prerendering
 By using the isomorphic code layout option, your project bundle will be outputted in a versatile universal code format allowing potential usage outside the browser. The Enact CLI takes advantage of this mode by additionally generating an HTML output of your project and embedding it directly with the resulting **index.html**. By default, isomorphic mode will attempt to prerender only `en-US`, however with the `--locales` option, a wide variety of locales can be specified and prerendered. More details on isomorphic support and its limitations can be found [here](./isomorphic-support.md).

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -226,17 +226,17 @@ For supporting better [`Caching`](https://webpack.js.org/guides/caching/), Enact
 Building With this option should produce the following output:
 
 ```none
-                       Asset       Size  Chunks                    Chunk Names
-main.7e2c49a622975ebd9b7e.js     544 kB       0  [emitted]  [big]  main
-                  index.html  197 bytes          [emitted]
+        1.11 MB         dist/main.1983e557b9a705c83e72.js
+        199.85 kB       dist/main.2088c66150ab73b27793.css
 ```
 
 When the content changes, the output file name will change as well.
 ```none
-                       Asset       Size  Chunks                    Chunk Names
-main.205199ab45963f6a62ec.js     544 kB       0  [emitted]  [big]  main
-                  index.html  197 bytes          [emitted]
+        1.11 MB         dist/main.7544f55b64439c8d0f0e.js
+        199.85 kB       dist/main.2088c66150ab73b27793.css
 ```
+
+> **NOTE** The filename `main.*.js` will be changed after bundling, without changes. This is because webpack includes certain boilerplate, specifically the runtime and manifest, in the entry chunk.
 
 ## Isomorphic Support & Prerendering
 By using the isomorphic code layout option, your project bundle will be outputted in a versatile universal code format allowing potential usage outside the browser. The Enact CLI takes advantage of this mode by additionally generating an HTML output of your project and embedding it directly with the resulting **index.html**. By default, isomorphic mode will attempt to prerender only `en-US`, however with the `--locales` option, a wide variety of locales can be specified and prerendered. More details on isomorphic support and its limitations can be found [here](./isomorphic-support.md).

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -221,7 +221,7 @@ my-app/
 
 ## [contenthash] Injection
 
-For supporting [`Caching`](https://webpack.kr/guides/caching), Enact CLI supports content hash features. You can use the [`contenthash`](https://webpack.js.org/configuration/output/#template-strings) substitutions setting to define the names of your output files.
+For supporting [`Caching`](https://webpack.kr/guides/caching), Enact CLI supports adding the hash of the chunk. You can use the [`contenthash`](https://webpack.js.org/configuration/output/#template-strings) substitutions setting to define the names of your output files.
 
 The `contenthash` substitution will add a unique hash based on the content of an asset.
 ```none

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -221,7 +221,7 @@ my-app/
 
 ## Caching
 
-For supporting better [`Caching`](https://webpack.js.org/guides/caching/), Enact CLI provides `--content-hash` option to add a unique hash to each output file name based on the content of an asset.
+For supporting better [`caching`](https://webpack.js.org/guides/caching/), Enact CLI provides `--content-hash` option to add a unique hash to each output file name based on the content of an asset.
 
 Building With this option should produce the following output:
 

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -8,7 +8,7 @@ order: 4
     enact pack [options]
 
   Options
-    --content-hash    Add the hash of the chunk
+    --content-hash    Add a unique hash to output files based on the content of an asset
     -p, --production  Build in production mode
     -i, --isomorphic  Use isomorphic code layout
                       (includes prerendering)

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -8,7 +8,7 @@ order: 4
     enact pack [options]
 
   Options
-    --content-hash    Add a unique hash to output files based on the content of an asset
+    --content-hash    Add a unique hash to output file names based on the content of an asset
     -p, --production  Build in production mode
     -i, --isomorphic  Use isomorphic code layout
                       (includes prerendering)

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -8,11 +8,12 @@ order: 4
     enact pack [options]
 
   Options
-    -p, --production     Build in production mode
-    -i, --isomorphic     Use isomorphic code layout
-                         (includes prerendering)
-    -w, --watch          Rebuild on file changes
-    -l, --locales        Locales for isomorphic mode; one of:
+    --content-hash    Add the hash of the chunk
+    -p, --production  Build in production mode
+    -i, --isomorphic  Use isomorphic code layout
+                      (includes prerendering)
+    -w, --watch       Rebuild on file changes
+    -l, --locales     Locales for isomorphic mode; one of:
             <comma-separated-values> Locale list
             <JSON-filepath> - Read locales from JSON file
             "none" - Disable locale-specific handling
@@ -20,11 +21,10 @@ order: 4
             "tv" - Locales supported on webOS TV
             "signage" - Locales supported on webOS signage
             "all" - All locales that iLib supports
-    -s, --snapshot       Generate V8 snapshot blob
-                         (requires V8_MKSNAPSHOT set)
-    -c, --custom-skin    Build with a custom skin
-    -ch, --content-hash  Add the hash of the chunk
-    --stats              Output bundle analysis file
+    -s, --snapshot    Generate V8 snapshot blob
+                      (requires V8_MKSNAPSHOT set)
+    -c, --custom-skin Build with a custom skin
+    --stats           Output bundle analysis file
 
 ```
 Run within an Enact project's source code, the `enact pack` command (aliased as `npm run pack` or `npm run pack-p` for production) will process and bundle the js, css, and asset files into the `./dist` directory. An **index.html** file will be dynamically generated.


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Some Enact apps are running as hosted web app. We need to support a way for the client can update hosted app files if the app is updated so that the client doesn't stay with the local cache.

One of the possible candidates is to use webpack hash config when pack.
(Caching description: https://webpack.kr/guides/caching)
(Set output description: https://webpack.js.org/configuration/output/#outputfilename, https://webpack.js.org/configuration/output/#outputchunkfilename)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Add a pack option `--content-hash` to be used by the hosted web app
- If the option is true, add a unique hash value based on content to the output file name so that the changed files could be loaded again.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRP-3673

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)