### PR TITLE
Remove getCSSModuleLocalIdent and use cssModuleIdent only

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -23,7 +23,6 @@ const ForkTsCheckerWebpackPlugin =
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
-const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent');
 const getPublicUrlOrPath = require('react-dev-utils/getPublicUrlOrPath');
 const ModuleNotFoundPlugin = require('react-dev-utils/ModuleNotFoundPlugin');
 const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
@@ -32,7 +31,7 @@ const TerserPlugin = require('terser-webpack-plugin');
 const {DefinePlugin, EnvironmentPlugin} = require('webpack');
 const {
 	optionParser: app,
-	cssModuleIdent: getSimpleCSSModuleLocalIdent,
+	cssModuleIdent: getLocalIdent,
 	GracefulFsPlugin,
 	ILibPlugin,
 	WebOSMetaPlugin
@@ -86,9 +85,6 @@ module.exports = function (
 	// on or off by setting the GENERATE_SOURCEMAP environment variable.
 	const GENERATE_SOURCEMAP = process.env.GENERATE_SOURCEMAP || (isEnvProduction ? 'false' : 'true');
 	const shouldUseSourceMap = GENERATE_SOURCEMAP !== 'false';
-
-	const getLocalIdent =
-		process.env.SIMPLE_CSS_IDENT !== 'false' ? getSimpleCSSModuleLocalIdent : getCSSModuleLocalIdent;
 
 	// common function to get style loaders
 	const getStyleLoaders = (cssLoaderOptions = {}, preProcessor) => {


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When generating css, react-dev-utils generates hash.
However, when creating a hash, `+` is not excluded.
Other developers also had the same problem, so they requested a react-dev-utils PR as shown below, but it has not been merged for over a year, so it is difficult to expect anything.
https://github.com/facebook/create-react-app/pull/12013

For internal development purposes, a hashless getLocalIdent called `getSimpleCSSModuleLocalIdent` has been implemented in @enact/dev-utils in the past.
This issue can be resolved by stopping using React-dev-utils and adding an option to create hashes without the '+' in @enact/dev-utils. (this code is from https://github.com/facebook/create-react-app/pull/12013)

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove getCSSModuleLocalIdent and use cssModuleIdent only

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-200

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)