### PR TITLE
WRQ-27312: Add root node_modules directory in ILIB_BASE_PATH

### DIFF
--- a/config/jest/jest.config.js
+++ b/config/jest/jest.config.js
@@ -20,7 +20,7 @@ const rbConst = name =>
 		.toUpperCase() +
 	'_PATH';
 
-const iLibDirs = ['node_modules/@enact/i18n/ilib', 'node_modules/ilib', 'ilib'];
+const iLibDirs = ['node_modules/@enact/i18n/ilib', 'node_modules/ilib', 'ilib', '../../node_modules/ilib'];
 const globals = {
 	__DEV__: true,
 	ILIB_BASE_PATH: iLibDirs.find(f => fs.existsSync(path.join(app.context, f))) || iLibDirs[1],


### PR DESCRIPTION
### Checklist

* [ ] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [ ] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When testing WRQ-26798, `npm run test` fails in enact/i18n as Jest cannot find ilib that resides not under i18n/node_modules anymore but under the root node_modules. 
So, maybe 'jest.config.js' of CLI needs to be updated.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Add root node_modules directory in `ILIB_BASE_PATH`

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRQ-27312

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong ([taeyoung.hong@lge.com](mailto:taeyoung.hong@lge.com))