### PR TITLE
WRR-3401: Added a build option to support Suspense with snapshot build

### DIFF
--- a/commands/pack.js
+++ b/commands/pack.js
@@ -58,7 +58,7 @@ function displayHelp() {
 		Private Options:
 			--entry              	Specify an override entrypoint
 			--no-minify           	Will skip minification during production build
-			--no-split-css			Will not split CSS into separate files
+			--no-split-css        	Will not split CSS into separate files
 			--framework           	Builds the @enact/*, react, and react-dom into an external framework
 			--externals           	Specify a local directory path to the standalone external framework
 			--externals-public    	Remote public path to the external framework for use injecting into HTML

--- a/commands/pack.js
+++ b/commands/pack.js
@@ -58,6 +58,7 @@ function displayHelp() {
 		Private Options:
 			--entry              	Specify an override entrypoint
 			--no-minify           	Will skip minification during production build
+			--no-split-css			Will not split CSS into separate files
 			--framework           	Builds the @enact/*, react, and react-dom into an external framework
 			--externals           	Specify a local directory path to the standalone external framework
 			--externals-public    	Remote public path to the external framework for use injecting into HTML
@@ -258,6 +259,7 @@ function api(opts = {}) {
 		opts['content-hash'],
 		opts.isomorphic,
 		!opts.animation,
+		!opts['split-css'],
 		opts.framework,
 		opts['ilib-additional-path']
 	);
@@ -289,6 +291,7 @@ function cli(args) {
 			'content-hash',
 			'custom-skin',
 			'minify',
+			'split-css',
 			'framework',
 			'externals-corejs',
 			'stats',
@@ -301,7 +304,7 @@ function cli(args) {
 			'help'
 		],
 		string: ['externals', 'externals-public', 'locales', 'entry', 'ilib-additional-path', 'output', 'meta'],
-		default: {minify: true, animation: true},
+		default: {minify: true, 'split-css': true, animation: true},
 		alias: {
 			o: 'output',
 			p: 'production',

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -45,6 +45,7 @@ module.exports = function (
 	contentHash = false,
 	isomorphic = false,
 	noAnimation = false,
+	noSplitCSS = false,
 	framework = false,
 	ilibAdditionalResourcesPath
 ) {
@@ -451,7 +452,17 @@ module.exports = function (
 					parallel: true
 				}),
 				new CssMinimizerPlugin()
-			]
+			],
+			splitChunks: noSplitCSS && {
+				cacheGroups: {
+					styles: {
+						name: 'main',
+						type: 'css/mini-extract',
+						chunks: 'all',
+						enforce: true
+					}
+				}
+			}
 		},
 		plugins: [
 			// Generates an `index.html` file with the js and css tags injected.
@@ -495,7 +506,8 @@ module.exports = function (
 			!process.env.INLINE_STYLES &&
 				new MiniCssExtractPlugin({
 					filename: contentHash ? '[name].[contenthash].css' : '[name].css',
-					chunkFilename: contentHash ? 'chunk.[name].[contenthash].css' : 'chunk.[name].css'
+					chunkFilename: contentHash ? 'chunk.[name].[contenthash].css' : 'chunk.[name].css',
+					ignoreOrder: noSplitCSS
 				}),
 			// Webpack5 removed node polyfills but we need this to run screenshot tests
 			new NodePolyfillPlugin(),


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When an app used `React.Suspense` with `React.lazy` for the first screen and built the app with `snapshot` option, built result shows broken styles because some of CSS are not loaded well.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
As I analyzed from WRQ-28908, when we lazy load some components, Webpack does code spliting. Because it's lazy loaded, which means we can load it on demand, the bundler doesn't need to add it to the main artifacts. And when it runs, these modules are loaded via Promise asynchronously.
This seems reasonable, but when we lazy load the components for the very first screen, it could cause the above problem when it goes along with snapshot build.
While making a snapshot blob, the asynchronously loaded artifacts are not included in the blob so browser had no chance to load that code splited CSS files.
So I've added a build option for not spliting the CSS file refered to https://webpack.js.org/plugins/mini-css-extract-plugin/#extracting-all-css-in-a-single-file.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
- Added `ignoreOrder: noSplitCSS` in `MiniCssExtractPlugin`.
https://webpack.js.org/plugins/mini-css-extract-plugin/#remove-order-warnings


### Links
[//]: # (Related issues, references)
WRR-3401

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)