### PR TITLE
WRR-8543: Added `--hash-classnames` for building hashed classnames

### DIFF
--- a/commands/pack.js
+++ b/commands/pack.js
@@ -59,6 +59,7 @@ function displayHelp() {
 			--entry              	Specify an override entrypoint
 			--no-minify           	Will skip minification during production build
 			--no-split-css        	Will not split CSS into separate files
+			--hash-classnames      	Will hash classnames in CSS
 			--framework           	Builds the @enact/*, react, and react-dom into an external framework
 			--externals           	Specify a local directory path to the standalone external framework
 			--externals-public    	Remote public path to the external framework for use injecting into HTML
@@ -260,6 +261,7 @@ function api(opts = {}) {
 		opts.isomorphic,
 		!opts.animation,
 		!opts['split-css'],
+		opts['hash-classnames'],
 		opts.framework,
 		opts['ilib-additional-path']
 	);
@@ -299,6 +301,7 @@ function cli(args) {
 			'isomorphic',
 			'snapshot',
 			'animation',
+			'hash-classnames',
 			'verbose',
 			'watch',
 			'help'

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -46,6 +46,7 @@ module.exports = function (
 	isomorphic = false,
 	noAnimation = false,
 	noSplitCSS = false,
+	hashClassnames = false,
 	framework = false,
 	ilibAdditionalResourcesPath
 ) {
@@ -324,7 +325,7 @@ module.exports = function (
 							use: getStyleLoaders({
 								importLoaders: 1,
 								modules: {
-									...(isEnvProduction ? {} : {getLocalIdent})
+									...(hashClassnames ? {} : {getLocalIdent})
 								}
 							})
 						},
@@ -336,7 +337,7 @@ module.exports = function (
 								importLoaders: 1,
 								modules: {
 									...(app.forceCSSModules ? {} : {mode: 'icss'}),
-									...(!app.forceCSSModules && isEnvProduction ? {} : {getLocalIdent})
+									...(!app.forceCSSModules && hashClassnames ? {} : {getLocalIdent})
 								}
 							}),
 							// Don't consider CSS imports dead code even if the
@@ -350,7 +351,7 @@ module.exports = function (
 							use: getLessStyleLoaders({
 								importLoaders: 2,
 								modules: {
-									...(isEnvProduction ? {} : {getLocalIdent})
+									...(hashClassnames ? {} : {getLocalIdent})
 								}
 							})
 						},
@@ -360,7 +361,7 @@ module.exports = function (
 								importLoaders: 2,
 								modules: {
 									...(app.forceCSSModules ? {} : {mode: 'icss'}),
-									...(!app.forceCSSModules && isEnvProduction ? {} : {getLocalIdent})
+									...(!app.forceCSSModules && hashClassnames ? {} : {getLocalIdent})
 								}
 							}),
 							sideEffects: true
@@ -372,7 +373,7 @@ module.exports = function (
 							use: getScssStyleLoaders({
 								importLoaders: 3,
 								modules: {
-									...(isEnvProduction ? {} : {getLocalIdent})
+									...(hashClassnames ? {} : {getLocalIdent})
 								}
 							})
 						},
@@ -383,7 +384,7 @@ module.exports = function (
 								importLoaders: 3,
 								modules: {
 									...(app.forceCSSModules ? {} : {mode: 'icss'}),
-									...(!app.forceCSSModules && isEnvProduction ? {} : {getLocalIdent})
+									...(!app.forceCSSModules && hashClassnames ? {} : {getLocalIdent})
 								}
 							})
 						},

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -324,7 +324,7 @@ module.exports = function (
 							use: getStyleLoaders({
 								importLoaders: 1,
 								modules: {
-									getLocalIdent
+									...(isEnvProduction ? {} : {getLocalIdent})
 								}
 							})
 						},
@@ -335,7 +335,8 @@ module.exports = function (
 							use: getStyleLoaders({
 								importLoaders: 1,
 								modules: {
-									...(app.forceCSSModules ? {getLocalIdent} : {mode: 'icss'})
+									...(app.forceCSSModules ? {} : {mode: 'icss'}),
+									...(!app.forceCSSModules && isEnvProduction ? {} : {getLocalIdent})
 								}
 							}),
 							// Don't consider CSS imports dead code even if the
@@ -349,7 +350,7 @@ module.exports = function (
 							use: getLessStyleLoaders({
 								importLoaders: 2,
 								modules: {
-									getLocalIdent
+									...(isEnvProduction ? {} : {getLocalIdent})
 								}
 							})
 						},
@@ -358,7 +359,8 @@ module.exports = function (
 							use: getLessStyleLoaders({
 								importLoaders: 2,
 								modules: {
-									...(app.forceCSSModules ? {getLocalIdent} : {mode: 'icss'})
+									...(app.forceCSSModules ? {} : {mode: 'icss'}),
+									...(!app.forceCSSModules && isEnvProduction ? {} : {getLocalIdent})
 								}
 							}),
 							sideEffects: true
@@ -370,7 +372,7 @@ module.exports = function (
 							use: getScssStyleLoaders({
 								importLoaders: 3,
 								modules: {
-									getLocalIdent
+									...(isEnvProduction ? {} : {getLocalIdent})
 								}
 							})
 						},
@@ -380,7 +382,8 @@ module.exports = function (
 							use: getScssStyleLoaders({
 								importLoaders: 3,
 								modules: {
-									...(app.forceCSSModules ? {getLocalIdent} : {mode: 'icss'})
+									...(app.forceCSSModules ? {} : {mode: 'icss'}),
+									...(!app.forceCSSModules && isEnvProduction ? {} : {getLocalIdent})
 								}
 							})
 						},


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
To reduce the size of built Enact app's CSS, added a private build option `--hash-classnames`.

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Added a private build option `--hash-classnames`
Changed the webpack config to use [hash:base64] of css-loader's `localIdentName` property when the option is true.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-8543

### Comments
Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)