### PR TITLE
WRR-24215: Remove the old postcss module

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -128,8 +128,6 @@ module.exports = function (
 							// Fix and adjust for known flexbox issues
 							// See https://github.com/philipwalton/flexbugs
 							'postcss-flexbugs-fixes',
-							// Support @global-import syntax to import css in a global context.
-							'postcss-global-import',
 							// Transpile stage-3 CSS standards based on browserslist targets.
 							// See https://preset-env.cssdb.org/features for supported features.
 							// Includes support for targetted auto-prefixing.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -52,7 +52,6 @@
         "node-polyfill-webpack-plugin": "4.0.0",
         "postcss": "^8.4.49",
         "postcss-flexbugs-fixes": "^5.0.2",
-        "postcss-global-import": "^1.0.6",
         "postcss-loader": "^8.1.1",
         "postcss-normalize": "^13.0.1",
         "postcss-preset-env": "^10.1.3",
@@ -22469,16 +22468,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/css-selector-tokenizer": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz",
-      "integrity": "sha512-jWQv3oCEL5kMErj4wRnK/OPoBi0D+P1FR2cDCKYPaMeD2eW3/mttav8HT4hT1CKopiJI/psEULjkClhvJo4Lvg==",
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "fastparse": "^1.1.2"
-      }
-    },
     "node_modules/css-tree": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
@@ -30049,12 +30038,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fastparse": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
-      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
-      "license": "MIT"
-    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -35750,17 +35733,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.4"
-      }
-    },
-    "node_modules/postcss-global-import": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-global-import/-/postcss-global-import-1.0.6.tgz",
-      "integrity": "sha512-+vACUVuINEqRiN9gZsR6inKMSqSDmT19FDzhvouB0CXyQ1ARI+lhEGTPtNm1E+ymTzV6aAPfA7jo6tVimHKSDw==",
-      "license": "ISC",
-      "dependencies": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^6.0.14",
-        "resolve": "^1.1.7"
       }
     },
     "node_modules/postcss-image-set-function": {

--- a/package.json
+++ b/package.json
@@ -109,9 +109,6 @@
     "webpack": "^5.97.1",
     "webpack-dev-server": "^5.2.0"
   },
-  "overrides": {
-    "postcss": "^8.4.49"
-  },
   "optionalDependencies": {
     "fsevents": "^2.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "node-polyfill-webpack-plugin": "4.0.0",
     "postcss": "^8.4.49",
     "postcss-flexbugs-fixes": "^5.0.2",
-    "postcss-global-import": "^1.0.6",
     "postcss-loader": "^8.1.1",
     "postcss-normalize": "^13.0.1",
     "postcss-preset-env": "^10.1.3",


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [ ] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Remove the old postcss module

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove the old postcss module

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-24215

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)