### PR TITLE
WRR-29550: Fix eslint always runs in strict mode during enact pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unreleased
+
+### pack
+
+* Fixed `eslintWebpackPluginConfig` to not always run lint in strict mode when `enact pack`.
+
 ## 7.0.0 (June 10, 2025)
 
 * Updated dependencies.

--- a/config/eslintWebpackPluginConfig.js
+++ b/config/eslintWebpackPluginConfig.js
@@ -15,7 +15,7 @@ const hasJsxRuntime = (() => {
 	}
 })();
 
-const loadedEnactConfig = process.env.FRAMEWORK ? eslintConfigEnactStrict : eslintConfigEnact;
+const loadedEnactConfig = process.env.FRAMEWORK === true ? eslintConfigEnactStrict : eslintConfigEnact;
 
 module.exports = [
 	...loadedEnactConfig,


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix eslint always runs in strict mode during enact pack: https://github.com/enactjs/cli/issues/368

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Instead of checking whether the value of `process.env.FRAMEWORK` exists or not, change it to check whether it is `true` or not.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-29550

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)