### PR TITLE
WRR-30318: Fix DEPRECATED WARNING while 'enact serve'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unreleased
+
+### pack
+
+* Fixed webpack config to webpack noise constrained to errors only.
+
 ## 7.1.0 (July 18, 2025)
 
 ### pack

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -278,8 +278,8 @@ module.exports = function (
 		mode: isEnvProduction ? 'production' : 'development',
 		// Don't attempt to continue if there are any errors.
 		bail: true,
-		// Webpack noise constrained to errors and warnings
-		stats: 'errors-warnings',
+		// Webpack noise constrained to errors only
+		stats: 'errors-only',
 		// Use source maps during development builds or when specified by GENERATE_SOURCEMAP
 		devtool: shouldUseSourceMap && (isEnvProduction ? 'source-map' : 'cheap-module-source-map'),
 		// These are the "entry points" to our application.


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix DEPRECATED WARNING
(Fix enact framework directly or set the tool to not show the annoying warnings)
> ...
<w> DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in /home/worker/myapp/node_modules/@enact/limestone/styles/variables.less on line 630, column 36:
<w> 630                 - #guide.get-edge-size-difference(
<w> DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in /home/worker/myapp/node_modules/@enact/limestone/styles/variables.less on line 965, column 35:
<w> 965         - #guide.get-edge-size-difference(
<w> DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in /home/worker/myapp/node_modules/@enact/ui/styles/mixins.less on line 28, column 12:
<w> 28          .position(
<w> DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in /home/worker/myapp/node_modules/@enact/ui/styles/mixins.less on line 174, column 11:
<w> 174         .position(
<w> DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in /home/worker/myapp/node_modules/@enact/ui/styles/mixins.less on line 182, column 11:
<w> 182         .position(
<w> DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in /home/worker/myapp/node_modules/@enact/ui/styles/mixins.less on line 189, column 11:
<w> 189         .position(
...

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed webpack config to webpack noise constrained to errors only.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-30318

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)