### PR TITLE
WRR-1016: Add the '--no-linting' option while 'enact pack/serve'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### pack
 
+* Added `--no-linting` option to build without code linting.
 * Fixed webpack config to webpack noise constrained to errors only.
 
 ### test

--- a/commands/pack.js
+++ b/commands/pack.js
@@ -49,6 +49,7 @@ function displayHelp() {
 	console.log('                      (requires V8_MKSNAPSHOT set)');
 	console.log('    -m, --meta        JSON to override package.json enact metadata');
 	console.log('    -c, --custom-skin Build with a custom skin');
+	console.log('    --no-linting      Build without code linting');
 	console.log('    --no-animation    Build without effects such as animation and shadow');
 	console.log('    --stats           Output bundle analysis file');
 	console.log('    --verbose         Verbose log build details');
@@ -258,6 +259,7 @@ function api(opts = {}) {
 	const configFactory = require('../config/webpack.config');
 	const config = configFactory(
 		opts.production ? 'production' : 'development',
+		!opts.linting
 		opts['content-hash'],
 		opts.isomorphic,
 		!opts.animation,
@@ -289,6 +291,7 @@ function api(opts = {}) {
 function cli(args) {
 	const opts = minimist(args, {
 		boolean: [
+			'linting',
 			'content-hash',
 			'custom-skin',
 			'minify',
@@ -305,7 +308,7 @@ function cli(args) {
 			'help'
 		],
 		string: ['externals', 'externals-public', 'locales', 'entry', 'ilib-additional-path', 'output', 'meta'],
-		default: {minify: true, 'split-css': true, animation: true},
+		default: {minify: true, 'split-css': true, animation: true, linting: true},
 		alias: {
 			o: 'output',
 			p: 'production',

--- a/commands/pack.js
+++ b/commands/pack.js
@@ -259,7 +259,7 @@ function api(opts = {}) {
 	const configFactory = require('../config/webpack.config');
 	const config = configFactory(
 		opts.production ? 'production' : 'development',
-		!opts.linting
+		!opts.linting,
 		opts['content-hash'],
 		opts.isomorphic,
 		!opts.animation,

--- a/commands/serve.js
+++ b/commands/serve.js
@@ -57,6 +57,7 @@ function displayHelp() {
 	console.log('    -f, --fast        Enables experimental frast refresh');
 	console.log('    -p, --port        Server port number');
 	console.log('    -m, --meta        JSON to override package.json enact metadata');
+	console.log('    --no-linting      Build without code linting');
 	console.log('    -v, --version     Display version information');
 	console.log('    -h, --help        Display help information');
 	console.log();
@@ -337,7 +338,7 @@ function api(opts) {
 	// Setup the development config with additional webpack-dev-server customizations.
 	const configFactory = require('../config/webpack.config');
 	const fastRefresh = process.env.FAST_REFRESH || opts.fast;
-	const config = hotDevServer(configFactory('development'), fastRefresh);
+	const config = hotDevServer(configFactory('development', !opts.linting), fastRefresh);
 
 	// Tools like Cloud9 rely on this.
 	const host = process.env.HOST || opts.host || '0.0.0.0';
@@ -354,7 +355,8 @@ function api(opts) {
 function cli(args) {
 	const opts = minimist(args, {
 		string: ['host', 'port', 'meta'],
-		boolean: ['browser', 'fast', 'help'],
+		boolean: ['browser', 'fast', 'help', 'linting'],
+		default: {linting: true},
 		alias: {b: 'browser', i: 'host', p: 'port', f: 'fast', m: 'meta', h: 'help'}
 	});
 	if (opts.help) displayHelp();

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -42,6 +42,7 @@ const createEnvironmentHash = require('./createEnvironmentHash');
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
 module.exports = function (
 	env,
+	noLinting = false,
 	contentHash = false,
 	isomorphic = false,
 	noAnimation = false,
@@ -659,17 +660,18 @@ module.exports = function (
 						infrastructure: 'silent'
 					}
 				}),
-			new ESLintPlugin({
-				// Plugin options
-				configType: 'flat',
-				extensions: ['js', 'mjs', 'jsx', 'ts', 'tsx'],
-				formatter: require.resolve('react-dev-utils/eslintFormatter'),
-				eslintPath: require.resolve('eslint'),
-				// @remove-on-eject-begin
-				overrideConfigFile: require.resolve('./eslintWebpackPluginConfig'),
-				// @remove-on-eject-end
-				cache: true
-			})
+			!noLinting &&
+				new ESLintPlugin({
+					// Plugin options
+					configType: 'flat',
+					extensions: ['js', 'mjs', 'jsx', 'ts', 'tsx'],
+					formatter: require.resolve('react-dev-utils/eslintFormatter'),
+					eslintPath: require.resolve('eslint'),
+					// @remove-on-eject-begin
+					overrideConfigFile: require.resolve('./eslintWebpackPluginConfig'),
+					// @remove-on-eject-end
+					cache: true
+				})
 		].filter(Boolean)
 	};
 };

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -15,8 +15,8 @@ order: 4
     -i, --isomorphic  Use isomorphic code layout
                       (includes prerendering)
     -l, --locales     Locales for isomorphic mode; one of:
-            <comma-separated-values> Locale list
-            <JSON-filepath> - Read locales from JSON file
+            [comma-separated-values] Locale list
+            [JSON-filepath] - Read locales from JSON file
             "none" - Disable locale-specific handling
             "used" - Detect locales used within ./resources/
             "tv" - Locales supported on webOS TV

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -15,8 +15,8 @@ order: 4
     -i, --isomorphic  Use isomorphic code layout
                       (includes prerendering)
     -l, --locales     Locales for isomorphic mode; one of:
-            [comma-separated-values] Locale list
-            [JSON-filepath] - Read locales from JSON file
+            <comma-separated-values> Locale list
+            <JSON-filepath> - Read locales from JSON file
             "none" - Disable locale-specific handling
             "used" - Detect locales used within ./resources/
             "tv" - Locales supported on webOS TV
@@ -26,6 +26,7 @@ order: 4
                       (requires V8_MKSNAPSHOT set)
     -m, --meta        JSON to override package.json enact metadata
     -c, --custom-skin Build with a custom skin
+    --no-linting      Build without code linting
     --no-animation    Build without effects such as animation and shadow
     --stats           Output bundle analysis file
     --verbose         Verbose log build details

--- a/docs/serving-apps.md
+++ b/docs/serving-apps.md
@@ -10,7 +10,12 @@ order: 6
   Options
     -b, --browser     Automatically open browser
     -i, --host        Server host IP address
+    -f, --fast        Enables experimental frast refresh
     -p, --port        Server port number
+    -m, --meta        JSON to override package.json enact metadata
+    --no-linting      Build without code linting
+    -v, --version     Display version information
+    -h, --help        Display help information
 ```
 The `enact serve` command (aliased as `npm run serve`) will build and host your project on **http://localhost:8080/**. The options allow you to customize the host IP and host port, which can also be overriden via `HOST` and `PORT` environment variable. While the `enact serve` is active, any changes to source code will trigger a rebuild and update any loaded browser windows.
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -27899,6 +27899,7 @@
       "version": "16.3.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
       "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Add the '--no-linting' option while 'enact pack/serve'

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
- Add the '--no-linting' option in `commands/pack.js` and `commands/serve.js`.
  - Add in `opts`.
  - Add in `--help`.
- Add the `noLinting` parameter in `webpack.config.js` to skip linting.
- Add the '--no-linting' option in docs.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-1016

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)