### PR TITLE
NXT-15922: Fix less -> css transpile issue while 'enact transpile'

### DIFF
--- a/commands/transpile.js
+++ b/commands/transpile.js
@@ -15,7 +15,7 @@ LessPluginRi.prototype.install = function (_less, pluginManager) {
 	const origParseString = Plugin.prototype.parseString;
 	Plugin.prototype.parseString = function (ruleNode, stringValues) {
 		const value = stringValues || ruleNode.value;
-		if (/calc\s*\(.*var\s*\(/.test(value)) return value;
+		if (/calc\s*\(/.test(value)) return value;
 		return origParseString.call(this, ruleNode, stringValues);
 	};
 	pluginManager.addVisitor(new Plugin(this.options));

--- a/commands/transpile.js
+++ b/commands/transpile.js
@@ -10,8 +10,8 @@ const LessPluginRi = require('resolution-independence');
 const getRiPlugin = require('resolution-independence/lib/resolution-independence');
 // Patch: calc() containing var() must pass through unchanged — the RI plugin's
 // parseString regex groups "calc(132px" as one token, causing parseFloat to return NaN.
-LessPluginRi.prototype.install = function (less, pluginManager) {
-	const Plugin = getRiPlugin(less);
+LessPluginRi.prototype.install = function (_less, pluginManager) {
+	const Plugin = getRiPlugin(_less);
 	const origParseString = Plugin.prototype.parseString;
 	Plugin.prototype.parseString = function (ruleNode, stringValues) {
 		const value = stringValues || ruleNode.value;

--- a/commands/transpile.js
+++ b/commands/transpile.js
@@ -7,6 +7,19 @@ const less = require('less');
 const LessPluginResolve = require('less-plugin-npm-import');
 const minimist = require('minimist');
 const LessPluginRi = require('resolution-independence');
+const getRiPlugin = require('resolution-independence/lib/resolution-independence');
+// Patch: calc() containing var() must pass through unchanged — the RI plugin's
+// parseString regex groups "calc(132px" as one token, causing parseFloat to return NaN.
+LessPluginRi.prototype.install = function (less, pluginManager) {
+	const Plugin = getRiPlugin(less);
+	const origParseString = Plugin.prototype.parseString;
+	Plugin.prototype.parseString = function (ruleNode, stringValues) {
+		const value = stringValues || ruleNode.value;
+		if (/calc\s*\(.*var\s*\(/.test(value)) return value;
+		return origParseString.call(this, ruleNode, stringValues);
+	};
+	pluginManager.addVisitor(new Plugin(this.options));
+};
 const {optionParser: app} = require('@enact/dev-utils');
 
 let chalk;


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Fix less -> css transpile issue while `enact transpile`

Reproduction steps
```
//0. use cli 7.3.2
$ npm i -g @enact/cli@7.3.2

//1. create an sample app
$ enact create myapp

//2. use Panels, Panel in the sample app
$ vi ...

//3. enact pack/serve and check css files
$ enact pack && enact serve
```
Expect: css looks fine, and panel works fine.
Actual: css looks weird, and panel not works
※ It cannot be reproduced when linking limestone directly, just `npm install @enact/limestone` cases
※ If you intend to link, you can reproduce the issue by running `enact transpile` on Limestone first. 

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Fixed an issue where information was missing from CSS files when executing the `enact transpile` command in Limestone,
by injecting monkey-patch at `LessPluginRi.prototype.install` in `transpile.js`
-> Fall-throughing calc()+var() pattern

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
NXT-15922

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)