### PR TITLE
NXT-17571: Support npm lockfileVersion 2 and 3 in bootstrap --override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unreleased
+
+### bootstrap
+
+* Fixed `--override` to support `package-lock.json` with `lockfileVersion` 2 and 3.
+
 ## 7.3.3 (July 7, 2026)
 
 ### transpile

--- a/commands/bootstrap.js
+++ b/commands/bootstrap.js
@@ -98,7 +98,7 @@ function api ({
 						}
 						// Update dependency entry for local entries that exist
 						local.forEach(dep => {
-							const fileDep = 'file:' + path.join(override, dep, 'package.tgz');
+							const fileDep = 'file:' + path.join(override, dep, 'package.tgz').split(path.sep).join('/');
 							if (!lockfile) {
 								if (obj.dependencies && obj.dependencies[dep]) {
 									obj.dependencies[dep] = fileDep;
@@ -125,9 +125,9 @@ function api ({
 								Object.keys(obj.packages)
 									.filter(key => key === suffix || key.endsWith('/' + suffix))
 									.forEach(key => {
-										obj.packages[key].version = fileDep;
+										obj.packages[key].resolved = fileDep;
 										// Remove unneeded properties to avoid issues
-										['resolved', 'from', 'integrity', 'requires'].forEach(
+										['version', 'from', 'integrity', 'requires'].forEach(
 											k => delete obj.packages[key][k]
 										);
 									});

--- a/commands/bootstrap.js
+++ b/commands/bootstrap.js
@@ -84,31 +84,61 @@ function api ({
 				['package.json', 'package-lock.json', 'npm-shrinkwrap.json']
 					.map(f => path.join(cwd, f))
 					.filter(f => fs.existsSync(f))
-					.forEach((f, i) => {
-						const lockfile = i > 0;
+					.forEach(f => {
+						const lockfile = path.basename(f) !== 'package.json';
 						// Restore any detected backups
 						if (fs.existsSync(f + '.bak')) {
 							fs.unlinkSync(f);
 							fs.renameSync(f + '.bak', f);
 						}
 						const obj = JSON.parse(fs.readFileSync(f, {encoding: 'utf8'}));
+						if (lockfile) {
+							obj.lockfileVersion = obj.lockfileVersion || 1;
+							obj.requires = true;
+						}
 						// Update dependency entry for local entries that exist
-						local
-							.filter(dep => obj.dependencies && obj.dependencies[dep])
-							.forEach(dep => {
-								const fileDep = 'file:' + path.join(override, dep, 'package.tgz');
-								if (lockfile) {
-									obj.lockfileVersion = obj.lockfileVersion || 1;
-									obj.requires = true;
-									obj.dependencies[dep].version = fileDep;
-									// Remove unneeded properties to avoid issues
-									['resolved', 'from', 'integrity', 'requires'].forEach(
-										key => delete obj.dependencies[dep][key]
-									);
-								} else {
+						local.forEach(dep => {
+							const fileDep = 'file:' + path.join(override, dep, 'package.tgz');
+							if (!lockfile) {
+								if (obj.dependencies && obj.dependencies[dep]) {
 									obj.dependencies[dep] = fileDep;
 								}
-							});
+								return;
+							}
+							// lockfileVersion 1 (and the legacy tree kept in v2):
+							// the flat "dependencies" map keyed by package name
+							if (obj.dependencies && obj.dependencies[dep]) {
+								obj.dependencies[dep].version = fileDep;
+								// Remove unneeded properties to avoid issues
+								['resolved', 'from', 'integrity', 'requires'].forEach(
+									key => delete obj.dependencies[dep][key]
+								);
+							}
+							// lockfileVersion 2 & 3: the "packages" map keyed by
+							// install path (e.g. "node_modules/@enact/core")
+							if (obj.packages) {
+								const nodeModulesKey = 'node_modules/' + dep;
+								if (obj.packages[nodeModulesKey]) {
+									obj.packages[nodeModulesKey].resolved = fileDep;
+									// Remove unneeded properties to avoid issues
+									['from', 'integrity'].forEach(
+										key => delete obj.packages[nodeModulesKey][key]
+									);
+								}
+								// The root package ("") mirrors package.json's
+								// dependency specifiers
+								const root = obj.packages[''];
+								if (root) {
+									['dependencies', 'devDependencies', 'optionalDependencies'].forEach(
+										depType => {
+											if (root[depType] && root[depType][dep]) {
+												root[depType][dep] = fileDep;
+											}
+										}
+									);
+								}
+							}
+						});
 						// Backup existing and write the newly modified file
 						fs.renameSync(f, f + '.bak');
 						fs.writeFileSync(f, JSON.stringify(obj, null, '  '), {encoding: 'utf8'});

--- a/commands/bootstrap.js
+++ b/commands/bootstrap.js
@@ -117,20 +117,23 @@ function api ({
 							// lockfileVersion 2 & 3: the "packages" map keyed by
 							// install path (e.g. "node_modules/@enact/core")
 							if (obj.packages) {
-								// A dependency can be installed at the top level
-								// ("node_modules/@enact/core") or nested
-								// ("node_modules/@enact/limestone/node_modules/@enact/core"),
-								// so update every path that resolves to this package.
-								const suffix = 'node_modules/' + dep;
+								// The top-level install ("node_modules/@enact/core")
+								// gets pointed at the local tgz.
+								const topKey = 'node_modules/' + dep;
+								if (obj.packages[topKey]) {
+									obj.packages[topKey].resolved = fileDep;
+									// Remove unneeded properties to avoid issues
+									['from', 'integrity', 'requires'].forEach(
+										k => delete obj.packages[topKey][k]
+									);
+								}
+								// Nested installs
+								// ("node_modules/@enact/limestone/node_modules/@enact/core")
+								// are removed so the dependent resolves to the
+								// overridden top-level package instead.
 								Object.keys(obj.packages)
-									.filter(key => key === suffix || key.endsWith('/' + suffix))
-									.forEach(key => {
-										obj.packages[key].resolved = fileDep;
-										// Remove unneeded properties to avoid issues
-										['version', 'from', 'integrity', 'requires'].forEach(
-											k => delete obj.packages[key][k]
-										);
-									});
+									.filter(key => key.endsWith('/' + topKey))
+									.forEach(key => delete obj.packages[key]);
 								// The root package ("") mirrors package.json's
 								// dependency specifiers
 								const root = obj.packages[''];

--- a/commands/bootstrap.js
+++ b/commands/bootstrap.js
@@ -117,15 +117,20 @@ function api ({
 							// lockfileVersion 2 & 3: the "packages" map keyed by
 							// install path (e.g. "node_modules/@enact/core")
 							if (obj.packages) {
-								const nodeModulesKey = 'node_modules/' + dep;
-								if (obj.packages[nodeModulesKey]) {
-									obj.packages[nodeModulesKey].version = fileDep;
-									obj.packages[nodeModulesKey].resolved = fileDep;
-									// Remove unneeded properties to avoid issues
-									['from', 'integrity', 'requires'].forEach(
-										key => delete obj.packages[nodeModulesKey][key]
-									);
-								}
+								// A dependency can be installed at the top level
+								// ("node_modules/@enact/core") or nested
+								// ("node_modules/@enact/limestone/node_modules/@enact/core"),
+								// so update every path that resolves to this package.
+								const suffix = 'node_modules/' + dep;
+								Object.keys(obj.packages)
+									.filter(key => key === suffix || key.endsWith('/' + suffix))
+									.forEach(key => {
+										obj.packages[key].version = fileDep;
+										// Remove unneeded properties to avoid issues
+										['resolved', 'from', 'integrity', 'requires'].forEach(
+											k => delete obj.packages[key][k]
+										);
+									});
 								// The root package ("") mirrors package.json's
 								// dependency specifiers
 								const root = obj.packages[''];

--- a/commands/bootstrap.js
+++ b/commands/bootstrap.js
@@ -119,9 +119,10 @@ function api ({
 							if (obj.packages) {
 								const nodeModulesKey = 'node_modules/' + dep;
 								if (obj.packages[nodeModulesKey]) {
+									obj.packages[nodeModulesKey].version = fileDep;
 									obj.packages[nodeModulesKey].resolved = fileDep;
 									// Remove unneeded properties to avoid issues
-									['from', 'integrity'].forEach(
+									['from', 'integrity', 'requires'].forEach(
 										key => delete obj.packages[nodeModulesKey][key]
 									);
 								}


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] I have run automated testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
Fixes `enact bootstrap --override` not supporting npm `package-lock.json` with `lockfileVersion` 2 or 3.

The existing override logic only rewrites the top-level `dependencies` tree used by lockfileVersion 1. lockfileVersion 2 keeps that tree for backwards compatibility, but **lockfileVersion 3 drops the `dependencies` tree and uses only the `packages` map**. As a result, on a v3 lockfile the override silently found nothing to rewrite and no-oped.

### Resolution
Added `packages` map handling to the override lockfile-rewriting logic in `commands/bootstrap.js`.

- **`packages` map (v2 & v3):** sets each `node_modules/<dep>` entry's `resolved` to the local `file:...tgz` path and removes `from`/`integrity`. Also updates the root package (`""`) `dependencies`/`devDependencies`/`optionalDependencies` specifiers.
- **`dependencies` tree (v1, and the legacy tree kept in v2):** behavior preserved for backwards compatibility.
- Moved the `lockfileVersion`/`requires` metadata assignment out of the dep loop so it is set correctly even when no dependency matches.
- Changed the lockfile check from an array index (`i > 0`) to a filename check (`path.basename(f) !== 'package.json'`) to avoid a misidentification when `package.json` is absent.

### Additional Considerations
Should be verified against projects whose `package-lock.json` uses lockfileVersion 1, 2, and 3 respectively, to confirm `--override` correctly swaps in the local tgz dependencies in each case.

### Links
NXT-17571

### Comments